### PR TITLE
Autofit column widths on double-click

### DIFF
--- a/src/components/DataTable.css
+++ b/src/components/DataTable.css
@@ -117,17 +117,18 @@ body.theme-dark .dt--zebra .dt__row--body:nth-child(even) .dt__cell--body {
 .dt__resize {
   position: absolute;
   top: 0;
-  right: -3px;            /* small overlap for easy grab */
-  width: 8px;
+  right: -3px;
+  width: 8px;              /* makes grabbing & double-click easier */
   height: 100%;
   cursor: col-resize;
-  touch-action: none;     /* prevent touch scrolling while resizing */
-  /* subtle visual (only on hover/focus to avoid visual noise) */
+  touch-action: none;
   background: transparent;
 }
+
 .dt__resize:hover {
   background: color-mix(in oklch, var(--primary-weak), var(--bg) 65%);
 }
+
 
 /* When resizable globally, ensure header has relative positioning */
 .dt--resizable .dt__cell--head {

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -293,6 +293,94 @@ export function DataTable<T>({
     headRefs.current[id] = el;
   };
 
+    // Utility: clamp a number
+  const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
+
+  // Get a css numeric property (e.g., padding) as number
+  const cssPx = (el: Element, prop: string) =>
+    parseFloat(getComputedStyle(el).getPropertyValue(prop)) || 0;
+
+  // Measure the natural width of a cell as rendered (scrollWidth already includes padding)
+  const measureCell = (cell: HTMLElement) => {
+    // Some cells may contain buttons / inline-blocks; scrollWidth captures full content width.
+    return Math.ceil(cell.scrollWidth);
+  };
+
+  // Find column index by id
+  const findColIndex = (id: string) => columns.findIndex(c => c.id === id);
+
+  // Measure max width among header + all rendered body cells in a given column
+  const getMaxNaturalWidthInColumn = (colId: string): number => {
+    const th = headRefs.current[colId];
+    if (!th) return 160;
+
+    // Header width
+    let max = measureCell(th);
+
+    // Include a small buffer for sort arrow/handle gutter
+    const resizeGutter = 12;
+    max += resizeGutter;
+
+    // Body cells
+    const table = th.closest('table');
+    if (!table) return max;
+
+    const colIdx = findColIndex(colId);
+    if (colIdx < 0) return max;
+
+    // Look through visible rows only (pagedRows or server-provided rows),
+    // which is what is actually rendered in the DOM and cheap to measure.
+    // We inspect the first TBODY.
+    const tb = table.tBodies?.[0];
+    if (!tb) return max;
+
+    // Iterate rows and measure the target column cell
+    for (const row of Array.from(tb.rows)) {
+      const cell = row.cells[colIdx] as HTMLTableCellElement | undefined;
+      if (!cell) continue;
+      const w = measureCell(cell);
+      if (w > max) max = w;
+    }
+
+    // Add a small safety buffer to reduce re-wrap flicker
+    const safety = 8;
+    return max + safety;
+  };
+
+  // Double-click handler: auto-fit column to content
+  const onResizeDoubleClick = (col: ColumnDef<T>, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Respect per-column/table resizable flags
+    if (!(col.resizable ?? resizable)) return;
+
+    // Determine constraints
+    const min = Math.max(60, col.minWidth ?? 80);
+    const max = Math.max(min, col.maxWidth ?? 800);
+
+    // Measure content width
+    const natural = getMaxNaturalWidthInColumn(col.id);
+    const fitted = clamp(natural, min, max);
+
+    // Apply width (store as px number)
+    setColWidths(prev => ({ ...prev, [col.id]: fitted }));
+
+    // Optional callback
+    if (onColumnResizeEnd) {
+      const out: Record<string, number | undefined> = {};
+      for (const c of columns) {
+        const w = c.id === col.id ? fitted : prevWidthNumber(colWidths[c.id]);
+        out[c.id] = w;
+      }
+      onColumnResizeEnd(out);
+    }
+  };
+
+  // Helper: normalize current column width to a px number if available
+  const prevWidthNumber = (w: number | string | undefined): number | undefined =>
+    typeof w === 'number' ? w : undefined;  
+  
   const resizingRef = useRef<{
     id: string;
     startX: number;
@@ -452,6 +540,7 @@ export function DataTable<T>({
                         <span
                           className="dt__resize"
                           onPointerDown={(e) => onResizePointerDown(c, e)}
+                          onDoubleClick={(e) => onResizeDoubleClick(c, e)}
                           role="separator"
                           aria-orientation="vertical"
                           aria-label={


### PR DESCRIPTION
This pull request enhances the column resizing functionality in the `DataTable` component by introducing auto-fit on double-click and improving the measurement of column widths. The changes streamline user interactions for resizing columns and ensure that columns can be automatically adjusted to fit their content.

Improvements to column resizing and auto-fit:

* Added a double-click handler (`onResizeDoubleClick`) to the column resize handle, allowing users to auto-fit a column to its content width. This handler measures the maximum natural width among the header and all visible body cells, clamps it to the column's min/max constraints, and updates the column width accordingly. (`src/components/DataTable.tsx`, [[1]](diffhunk://#diff-3fd80f7ce4eed9fb9c23df0ce14230ff017fc9f4eed6a073617471370aeeb848R296-R383) [[2]](diffhunk://#diff-3fd80f7ce4eed9fb9c23df0ce14230ff017fc9f4eed6a073617471370aeeb848R543)
* Introduced utility functions (`clamp`, `cssPx`, `measureCell`, `findColIndex`, `getMaxNaturalWidthInColumn`, `prevWidthNumber`) to accurately measure cell content and handle width calculations for auto-fitting. (`src/components/DataTable.tsx`, [src/components/DataTable.tsxR296-R383](diffhunk://#diff-3fd80f7ce4eed9fb9c23df0ce14230ff017fc9f4eed6a073617471370aeeb848R296-R383))

Minor improvements to resize handle styling:

* Updated the comment in the `.dt__resize` CSS rule to clarify the purpose of the width property, making it easier to understand why the handle is sized for easier grabbing and double-clicking. (`src/components/DataTable.css`, [src/components/DataTable.cssL120-R132](diffhunk://#diff-5b5c30f2a32743d86f4fcfec06a0286ca1703ff73342086a0a4a4ab0ccbe33abL120-R132))