### PR TITLE
Add resizer to sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,20 +1,78 @@
 import { NavLink } from 'react-router-dom';
 import type { EndpointDef } from '../endpoints/registry';
+import { useEffect, useRef } from 'react';
 
 export function Sidebar({
   endpoints,
   open,
   onClose,
+  enableResize = true,
+  minWidth = 180,
+  maxWidth = 420,
+  persistKey = 'ui.sidebar.w',
 }: {
   endpoints: EndpointDef[];
   open: boolean;
   onClose?: () => void;
+  enableResize?: boolean;
+  minWidth?: number;
+  maxWidth?: number;
+  persistKey?: string;
 }) {
+  // Load saved width (once)
+  useEffect(() => {
+    const raw = localStorage.getItem(persistKey);
+    const val = raw ? Number(raw) : NaN;
+    if (!Number.isNaN(val) && val > 0) {
+      document.documentElement.style.setProperty('--sidebar-w', `${val}px`);
+    }
+  }, [persistKey]);
+
+  const dragRef = useRef<{ startX: number; startW: number } | null>(null);
+
+  const onPointerDown: React.PointerEventHandler<HTMLSpanElement> = (e) => {
+    if (!enableResize || window.matchMedia('(max-width: 899px)').matches) return; // desktop only
+    e.preventDefault();
+    e.stopPropagation();
+
+    const cur = getComputedStyle(document.documentElement).getPropertyValue('--sidebar-w').trim();
+    const startW = cur.endsWith('px') ? parseFloat(cur) : 240;
+
+    dragRef.current = { startX: e.clientX, startW: startW || 240 };
+    (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
+  const onMove = (e: PointerEvent) => {
+    const ctx = dragRef.current;
+    if (!ctx) return;
+    const next = Math.max(minWidth, Math.min(maxWidth, Math.round(ctx.startW + (e.clientX - ctx.startX))));
+    document.documentElement.style.setProperty('--sidebar-w', `${next}px`);
+  };
+
+  const onUp = () => {
+    const ctx = dragRef.current;
+    dragRef.current = null;
+
+    document.body.style.userSelect = '';
+    document.body.style.cursor = '';
+
+    window.removeEventListener('pointermove', onMove);
+    window.removeEventListener('pointerup', onUp);
+
+    // persist final value
+    const cur = getComputedStyle(document.documentElement).getPropertyValue('--sidebar-w').trim();
+    const px = cur.endsWith('px') ? parseFloat(cur) : NaN;
+    if (!Number.isNaN(px)) localStorage.setItem(persistKey, String(px));
+  };
+
   return (
-    <aside
-      className={`sidebar ${open ? 'open' : ''}`}
-      aria-label="Resource navigation"
-    >
+    <aside className={`sidebar ${open ? 'open' : ''}`} aria-label="Resource navigation">
       <div className="sidebar__header">
         <div className="sidebar__title">RMCE Objects</div>
       </div>
@@ -25,9 +83,7 @@ export function Sidebar({
             <li key={ep.id} className="sidebar__item">
               <NavLink
                 to={ep.path}
-                className={({ isActive }) =>
-                  `sidebar__link ${isActive ? 'active' : ''}`
-                }
+                className={({ isActive }) => `sidebar__link ${isActive ? 'active' : ''}`}
                 onClick={onClose}
               >
                 {ep.label}
@@ -38,10 +94,11 @@ export function Sidebar({
       </nav>
 
       <div className="sidebar__footer">
-        <small style={{ color: 'var(--muted)' }}>
-          v1 · {new Date().getFullYear()}
-        </small>
+        <small style={{ color: 'var(--muted)' }}>v1 · {new Date().getFullYear()}</small>
       </div>
+
+      {/* ⬇️ Desktop-only resizer grip */}
+      {enableResize && <span className="sidebar__grip" onPointerDown={onPointerDown} role="separator" aria-orientation="vertical" aria-label="Resize sidebar" />}
     </aside>
   );
 }

--- a/src/layout.css
+++ b/src/layout.css
@@ -208,6 +208,34 @@ body.theme-dark .sidebar__link:hover { background: color-mix(in oklch, var(--pan
   color: var(--muted);
 }
 
+/* Make sidebar a positioning context on desktop */
+@media (min-width: 900px) {
+  .sidebar { position: relative; }
+}
+
+/* The vertical grip on the right edge */
+.sidebar__grip {
+  display: none; /* hidden on mobile */
+}
+
+@media (min-width: 900px) {
+  .sidebar__grip {
+    display: block;
+    position: absolute;
+    top: 0;
+    right: -3px;              /* slight overlap into content area for easy grab */
+    width: 8px;
+    height: 100%;
+    cursor: col-resize;
+    background: transparent;
+    z-index: 25;              /* above sidebar content */
+    touch-action: none;
+  }
+  .sidebar__grip:hover {
+    background: color-mix(in oklch, var(--primary-weak), var(--bg) 65%);
+  }
+}
+
 /* Mobile backdrop when sidebar open */
 .backdrop {
   position: fixed;


### PR DESCRIPTION
This pull request adds a resizable sidebar feature to the application, allowing users to adjust the sidebar width on desktop devices and persist their preferred width across sessions. The changes include both functional updates in the `Sidebar` component and supporting CSS for the new grip element. The sidebar remains fixed in width on mobile devices.

Resizable sidebar functionality:

* Added logic to the `Sidebar` component to allow resizing via a draggable grip, with width constraints and persistence using `localStorage`. This includes new props (`enableResize`, `minWidth`, `maxWidth`, `persistKey`) and pointer event handlers for drag operations. (`src/components/Sidebar.tsx`, [src/components/Sidebar.tsxR3-R75](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR3-R75))
* Introduced a desktop-only grip element (`sidebar__grip`) for resizing, rendered conditionally based on the `enableResize` prop. (`src/components/Sidebar.tsx`, [src/components/Sidebar.tsxL41-R101](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cL41-R101))

Styling and layout support:

* Updated CSS to position the sidebar as a context for the grip, and styled the grip for desktop usage, including hover effects and hiding it on mobile. (`src/layout.css`, [src/layout.cssR211-R238](diffhunk://#diff-6ee587b4f30bda16e70ac27950a58a8d03e56fb50acc0d8d45287cd390c92f95R211-R238))

Minor code cleanup:

* Simplified the rendering of `NavLink` and footer elements in the sidebar for improved readability. (`src/components/Sidebar.tsx`, [[1]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cL28-R86) [[2]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cL41-R101)