### PR TITLE
Fix sidebar overlapping main display

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,7 +7,7 @@ export function Sidebar({
   open,
   onClose,
   enableResize = true,
-  minWidth = 180,
+  minWidth = 140,
   maxWidth = 420,
   persistKey = 'ui.sidebar.w',
 }: {

--- a/src/layout.css
+++ b/src/layout.css
@@ -73,9 +73,52 @@ button:hover {
 }
 
 /* Content area */
+/* The content area should not have negative margins. Make sure it's edge-aligned. */
 .content {
   background: var(--bg);
   color: var(--text);
+  box-sizing: border-box;
+  margin: 0;
+  padding: 16px;
+}
+
+/* Mobile defaults (overlay) are fine.
+   Desktop: switch to 2-column grid and static sidebar. */
+@media (min-width: 900px) {
+  .app {
+    display: grid;
+    grid-template-columns: var(--sidebar-w, 240px) 1fr;
+    grid-template-rows: 1fr;
+    width: 100%;
+    min-height: 100vh;
+  }
+
+  .topbar {
+    display: none;
+  }
+
+  .sidebar {
+    position: static;    /* no overlay on desktop */
+    transform: none;     /* disable translate from mobile */
+    height: auto;
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    z-index: 1;          /* below content if content has positioned children */
+  }
+
+  .content {
+    grid-row: 1 / 2;
+    grid-column: 2 / 3;
+    padding: 20px;
+    min-width: 0;        /* allow shrinking; prevents subtle overlap/overflow */
+    position: relative;  /* establishes stacking context for internal children */
+    z-index: 0;
+  }
+
+  /* Backdrop only used on mobile overlay. Hide on desktop to avoid any chance of stacking. */
+  .backdrop {
+    display: none !important;
+  }
 }
 
 /* App grid: 
@@ -107,6 +150,7 @@ button:hover {
 
 /* Sidebar overlay (mobile default) */
 .sidebar {
+  box-sizing: border-box;                     /* avoid spillover */
   grid-row: 2 / 3;
   grid-column: 1 / 2;
   background: var(--panel);


### PR DESCRIPTION
This pull request introduces improvements to the sidebar and content layout for both mobile and desktop views. The main changes focus on enhancing the responsiveness and usability of the sidebar, as well as refining the content area styling to ensure proper alignment and spacing.

Layout and responsiveness improvements:

* Added a desktop-specific grid layout for `.app`, switching to a two-column grid with a static sidebar and edge-aligned content area when the viewport is at least 900px wide. This ensures a more consistent and usable layout on larger screens.
* On desktop, the `.sidebar` is now positioned statically (not overlayed), and the `.topbar` and `.backdrop` are hidden to avoid unnecessary stacking and visual clutter.
* The `.content` area now uses `box-sizing: border-box`, has zero margins, and receives consistent padding for better alignment and spacing; on desktop, it also allows shrinking and establishes its own stacking context.
* The `.sidebar` uses `box-sizing: border-box` to prevent spillover and maintain proper sizing across layouts.

Sidebar usability:

* Reduced the minimum sidebar width from 180px to 140px in `Sidebar.tsx`, allowing for greater flexibility and usability, especially on smaller screens.