### PR TITLE
Use shared input views

### DIFF
--- a/src/components/inputs/LabeledInput.tsx
+++ b/src/components/inputs/LabeledInput.tsx
@@ -1,0 +1,80 @@
+import { useId, type InputHTMLAttributes } from 'react';
+
+export interface LabeledInputProps {
+  label: string;
+  value: string;
+  onChange: (val: string) => void;
+  type?: InputHTMLAttributes<HTMLInputElement>['type']; // 'text' | 'number' | ...
+  disabled?: boolean;
+  id?: string;
+  placeholder?: string;
+  required?: boolean;
+  autoComplete?: string;
+  inputProps?: Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'type' | 'disabled' | 'id'>;
+  /**
+   * EXACT OPTIONAL PROP (Fix A):
+   * When tsconfig has "exactOptionalPropertyTypes": true, an optional prop does NOT include undefined
+   * unless we state it. This allows passing `error={errors.id}` where type is `string | undefined`.
+   */
+  error?: string | undefined;
+  /** Optional helper text under the field (separate from error) */
+  helperText?: string | undefined;
+}
+
+export function LabeledInput({
+  label,
+  value,
+  onChange,
+  type = 'text',
+  disabled = false,
+  id,
+  placeholder,
+  required,
+  autoComplete,
+  inputProps,
+  error,
+  helperText,
+}: LabeledInputProps) {
+  const autoId = useId();
+  const inputId = id ?? `li-${autoId}`;
+  const errorId = error ? `${inputId}-error` : undefined;
+  const helperId = helperText ? `${inputId}-help` : undefined;
+
+  const describedBy = [errorId, helperId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <label htmlFor={inputId} style={{ display: 'grid', gap: 6, fontSize: 14 }}>
+      <span>{label}{required ? ' *' : ''}</span>
+      <input
+        id={inputId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        type={type}
+        disabled={disabled}
+        placeholder={placeholder}
+        required={required}
+        autoComplete={autoComplete}
+        aria-invalid={!!error}
+        aria-describedby={describedBy}
+        style={{
+          padding: 8,
+          border: error ? '1px solid #b00020' : '1px solid var(--border)',
+          outline: 'none',
+          background: 'var(--bg)',
+          color: 'var(--text)',
+        }}
+        {...inputProps}
+      />
+      {helperText && !error && (
+        <span id={helperId} style={{ color: 'var(--muted)', fontSize: 12 }}>
+          {helperText}
+        </span>
+      )}
+      {error && (
+        <span id={errorId} style={{ color: '#b00020', fontSize: 12 }}>
+          {error}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/src/components/inputs/LabeledSelect.tsx
+++ b/src/components/inputs/LabeledSelect.tsx
@@ -1,0 +1,80 @@
+import { useId, type SelectHTMLAttributes } from 'react';
+
+export interface LabeledSelectProps {
+  label: string;
+  value: string;
+  onChange: (val: string) => void;
+  options: readonly string[];
+  disabled?: boolean;
+  id?: string;
+  required?: boolean;
+  selectProps?: Omit<SelectHTMLAttributes<HTMLSelectElement>, 'value' | 'onChange' | 'disabled' | 'id' | 'required'>;
+  /**
+   * EXACT OPTIONAL PROP (Fix A)
+   */
+  error?: string | undefined;
+  /** A placeholder-like first option with empty value */
+  placeholderOption?: string | undefined;
+  helperText?: string | undefined;
+}
+
+export function LabeledSelect({
+  label,
+  value,
+  onChange,
+  options,
+  disabled = false,
+  id,
+  required,
+  selectProps,
+  error,
+  placeholderOption = '— Select —',
+  helperText,
+}: LabeledSelectProps) {
+  const autoId = useId();
+  const selectId = id ?? `ls-${autoId}`;
+  const errorId = error ? `${selectId}-error` : undefined;
+  const helperId = helperText ? `${selectId}-help` : undefined;
+
+  const describedBy = [errorId, helperId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <label htmlFor={selectId} style={{ display: 'grid', gap: 6, fontSize: 14 }}>
+      <span>{label}{required ? ' *' : ''}</span>
+      <select
+        id={selectId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        required={required}
+        aria-invalid={!!error}
+        aria-describedby={describedBy}
+        style={{
+          padding: 8,
+          border: error ? '1px solid #b00020' : '1px solid var(--border)',
+          outline: 'none',
+          background: 'var(--bg)',
+          color: 'var(--text)',
+        }}
+        {...selectProps}
+      >
+        <option value="">{placeholderOption}</option>
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+      {helperText && !error && (
+        <span id={helperId} style={{ color: 'var(--muted)', fontSize: 12 }}>
+          {helperText}
+        </span>
+      )}
+      {error && (
+        <span id={errorId} style={{ color: '#b00020', fontSize: 12 }}>
+          {error}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/src/components/inputs/index.ts
+++ b/src/components/inputs/index.ts
@@ -1,0 +1,2 @@
+export * from './LabeledInput';
+export * from './LabeledSelect';

--- a/src/endpoints/armourtypes/ArmourtypesView.tsx
+++ b/src/endpoints/armourtypes/ArmourtypesView.tsx
@@ -4,6 +4,7 @@ import { fetchArmourtypes, upsertArmourtype, deleteArmourtype } from './api';
 import type { Armourtype } from '../../types';
 import { useConfirm } from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
+import { LabeledInput } from '../../components/inputs';
 
 type ArmourNumberKey =
   | 'minManoeuvreMod'
@@ -375,33 +376,6 @@ return (
   }
 }
 
-function LabeledInput({
-  label,
-  value,
-  onChange,
-  type = 'text',
-  disabled = false,
-}: {
-  label: string;
-  value: string;
-  onChange: (val: string) => void;
-  type?: 'text' | 'number';
-  disabled?: boolean;
-}) {
-  return (
-    <label style={{ display: 'grid', gap: 6, fontSize: 14 }}>
-      <span>{label}</span>
-      <input
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        type={type}
-        disabled={disabled}
-        style={{ padding: 8 }}
-      />
-    </label>
-  );
-}
-
 function CheckboxInput({
   label,
   checked,
@@ -416,31 +390,6 @@ function CheckboxInput({
       <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
       <span>{label}</span>
     </label>
-  );
-}
-
-function SortableTh<T extends string>({
-  onClick,
-  label,
-  sort,
-  colKey,
-}: {
-  onClick: () => void;
-  label: string;
-  sort: { key: T; dir: 'asc' | 'desc' };
-  colKey: T;
-}) {
-  const active = sort.key === colKey;
-  const arrow = active ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : '';
-  return (
-    <th
-      onClick={onClick}
-      style={{ borderBottom: '1px solid #ddd', textAlign: 'left', padding: '8px', cursor: 'pointer', userSelect: 'none' }}
-      title={`Sort by ${label}`}
-      scope="col"
-    >
-      {label}{arrow}
-    </th>
   );
 }
 

--- a/src/endpoints/books/BooksView.tsx
+++ b/src/endpoints/books/BooksView.tsx
@@ -4,6 +4,7 @@ import { fetchBooks, upsertBook, deleteBook } from './api';
 import type { Book } from '../../types';
 import { useConfirm } from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
+import { LabeledInput } from '../../components/inputs';
 
 export default function BooksView() {
   const [rows, setRows] = useState<Book[]>([]);
@@ -89,11 +90,6 @@ export default function BooksView() {
     });
     return arr;
   }, [filtered, sort]);
-
-  const onSort = (key: keyof Book) =>
-    setSort((prev) =>
-      prev.key === key ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' }
-    );
 
   const startNew = () => {
     setEditingId(null);
@@ -271,58 +267,6 @@ return (
 );
 }
 
-
-function LabeledInput({
-  label,
-  value,
-  onChange,
-  type = 'text',
-  disabled = false,
-}: {
-  label: string;
-  value: string;
-  onChange: (val: string) => void;
-  type?: 'text' | 'number';
-  disabled?: boolean;
-}) {
-  return (
-    <label style={{ display: 'grid', gap: 6, fontSize: 14 }}>
-      <span>{label}</span>
-      <input
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        type={type}
-        disabled={disabled}
-        style={{ padding: 8 }}
-      />
-    </label>
-  );
-}
-
-function SortableTh<T extends string>({
-  onClick,
-  label,
-  sort,
-  colKey,
-}: {
-  onClick: () => void;
-  label: string;
-  sort: { key: T; dir: 'asc' | 'desc' };
-  colKey: T;
-}) {
-  const active = sort.key === colKey;
-  const arrow = active ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : '';
-  return (
-    <th
-      onClick={onClick}
-      style={{ borderBottom: '1px solid #ddd', textAlign: 'left', padding: '8px', cursor: 'pointer', userSelect: 'none' }}
-      title={`Sort by ${label}`}
-      scope="col"
-    >
-      {label}{arrow}
-    </th>
-  );
-}
 
 const tdStyle: React.CSSProperties = { borderBottom: '1px solid #f0f0f0', padding: '8px' };
 const emptyCell: React.CSSProperties = { padding: 12, textAlign: 'center', color: '#666' };

--- a/src/endpoints/climates/ClimateView.tsx
+++ b/src/endpoints/climates/ClimateView.tsx
@@ -5,6 +5,7 @@ import type { Climate, Precipitation, Temperature } from '../../types';
 import { PRECIPITATIONS, TEMPERATURES } from '../../types';
 import { useToast } from '../../components/Toast';
 import { useConfirm } from '../../components/ConfirmDialog';
+import { LabeledInput, LabeledSelect } from '../../components/inputs'
 
 export default function ClimateView() {
   const [rows, setRows] = useState<Climate[]>([]);
@@ -361,87 +362,6 @@ export default function ClimateView() {
         </div>
       )}
     </>
-  );
-}
-
-function LabeledInput({
-  label,
-  value,
-  onChange,
-  type = 'text',
-  disabled = false,
-  error,
-}: {
-  label: string;
-  value: string;
-  onChange: (val: string) => void;
-  type?: 'text';
-  disabled?: boolean;
-  error?: string | undefined;
-}) {
-  return (
-    <label style={{ display: 'grid', gap: 6, fontSize: 14 }}>
-      <span>{label}</span>
-      <input
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        type={type}
-        disabled={disabled}
-        aria-invalid={!!error}
-        aria-describedby={error ? `${label}-error` : undefined}
-        style={{
-          padding: 8,
-          border: error ? '1px solid #b00020' : '1px solid var(--border)',
-          outline: 'none',
-        }}
-      />
-      {error && (
-        <span id={`${label}-error`} style={{ color: '#b00020', fontSize: 12 }}>
-          {error}
-        </span>
-      )}
-    </label>
-  );
-}
-
-function LabeledSelect({
-  label,
-  value,
-  onChange,
-  options,
-  error,
-}: {
-  label: string;
-  value: string;
-  onChange: (val: string) => void;
-  options: readonly string[];
-  error?: string | undefined;
-}) {
-  return (
-    <label style={{ display: 'grid', gap: 6, fontSize: 14 }}>
-      <span>{label}</span>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        aria-invalid={!!error}
-        aria-describedby={error ? `${label}-error` : undefined}
-        style={{
-          padding: 8,
-          border: error ? '1px solid #b00020' : '1px solid var(--border)',
-          outline: 'none',
-        }}
-      >
-        <option value="">— Select —</option>
-        {options.map((opt) => (
-          <option key={opt} value={opt}>{opt}</option>
-        ))}
-      </select>
-      {error && (
-        <span id={`${label}-error`} style={{ color: '#b00020', fontSize: 12 }}>
-          {error}
-        </span>
-      )}
-    </label>
   );
 }
 

--- a/src/endpoints/poisons/PoisonsView.tsx
+++ b/src/endpoints/poisons/PoisonsView.tsx
@@ -4,6 +4,7 @@ import { fetchPoisons, upsertPoison, deletePoison } from './api';
 import type { Poison } from '../../types';
 import { useConfirm } from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';
+import { LabeledInput } from '../../components/inputs';
 
 type PoisonNumberKey = 'level';
 type PoisonStringKey = Exclude<keyof Poison, PoisonNumberKey>; // 'id' | 'name' | 'type' | 'levelVariance'
@@ -306,58 +307,6 @@ return (
       return next;
     });
   }
-}
-
-function LabeledInput({
-  label,
-  value,
-  onChange,
-  type = 'text',
-  disabled = false,
-}: {
-  label: string;
-  value: string;
-  onChange: (val: string) => void;
-  type?: 'text' | 'number';
-  disabled?: boolean;
-}) {
-  return (
-    <label style={{ display: 'grid', gap: 6, fontSize: 14 }}>
-      <span>{label}</span>
-      <input
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        type={type}
-        disabled={disabled}
-        style={{ padding: 8 }}
-      />
-    </label>
-  );
-}
-
-function SortableTh<T extends string>({
-  onClick,
-  label,
-  sort,
-  colKey,
-}: {
-  onClick: () => void;
-  label: string;
-  sort: { key: T; dir: 'asc' | 'desc' };
-  colKey: T;
-}) {
-  const active = sort.key === colKey;
-  const arrow = active ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : '';
-  return (
-    <th
-      onClick={onClick}
-      style={{ borderBottom: '1px solid #ddd', textAlign: 'left', padding: '8px', cursor: 'pointer', userSelect: 'none' }}
-      title={`Sort by ${label}`}
-      scope="col"
-    >
-      {label}{arrow}
-    </th>
-  );
 }
 
 const tdStyle: React.CSSProperties = { borderBottom: '1px solid #f0f0f0', padding: '8px' };


### PR DESCRIPTION
This pull request refactors input components across several endpoint views to use new, reusable `LabeledInput` and `LabeledSelect` components. This change improves code consistency, accessibility, and maintainability by eliminating duplicate implementations and centralizing input logic.

Reusable input components:

* Added new `LabeledInput` and `LabeledSelect` components in `src/components/inputs`, featuring enhanced accessibility, error handling, and customizable props. (`src/components/inputs/LabeledInput.tsx`, `src/components/inputs/LabeledSelect.tsx`) [[1]](diffhunk://#diff-bfdf7a9755f7f47c3b51dfaa8924d5628c5b18f0e98f7c62122d68e359aca0ceR1-R80) [[2]](diffhunk://#diff-e1131a17b5cd88af46adcf6d4c296aad91e97ccba65034130f8b11760de6509fR1-R80)
* Created a barrel export for these inputs in `src/components/inputs/index.ts` for easier imports.

Endpoint view refactoring:

* Updated `ArmourtypesView`, `BooksView`, `ClimateView`, and `PoisonsView` to import and use the new `LabeledInput` and/or `LabeledSelect` components, replacing their local implementations. (`src/endpoints/armourtypes/ArmourtypesView.tsx`, `src/endpoints/books/BooksView.tsx`, `src/endpoints/climates/ClimateView.tsx`, `src/endpoints/poisons/PoisonsView.tsx`) [[1]](diffhunk://#diff-cf579bb1c309d30f531caf781528beec54782339c081b2369db3685eeccb7fecR7) [[2]](diffhunk://#diff-93dfdbe080c1c2be2bfc7f8905296aab045b5e1b9f6df05e4d8f4cc5c6d833f1R7) [[3]](diffhunk://#diff-092866cc2b294b80feb18e7b534459a5963768961e09d4eed5fd88b3e61c1d5dR8) [[4]](diffhunk://#diff-bb29f296b459be0390a327a267d57c215efa94348f6d637a37017526debcf9bfR7)
* Removed all local definitions of `LabeledInput`, `LabeledSelect`, and `SortableTh` from the endpoint views, reducing code duplication and simplifying the files. [[1]](diffhunk://#diff-cf579bb1c309d30f531caf781528beec54782339c081b2369db3685eeccb7fecL378-L404) [[2]](diffhunk://#diff-93dfdbe080c1c2be2bfc7f8905296aab045b5e1b9f6df05e4d8f4cc5c6d833f1L275-L326) [[3]](diffhunk://#diff-092866cc2b294b80feb18e7b534459a5963768961e09d4eed5fd88b3e61c1d5dL367-L447) [[4]](diffhunk://#diff-bb29f296b459be0390a327a267d57c215efa94348f6d637a37017526debcf9bfL311-L362)

These changes collectively make the codebase more maintainable and ensure consistent behavior and styling for input fields throughout the application.