### PR TITLE
Apply theme consistently

### DIFF
--- a/src/endpoints/armourtypes/ArmourtypesView.tsx
+++ b/src/endpoints/armourtypes/ArmourtypesView.tsx
@@ -262,7 +262,7 @@ return (
 
     {/* Form panel (unchanged) */}
     {showForm && (
-      <div style={{ border: '1px solid #ddd', borderRadius: 8, padding: 12, marginBottom: 16, background: '#fafafa' }}>
+      <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
         <h3 style={{ marginTop: 0 }}>{editingId ? 'Edit Armourtype' : 'New Armourtype'}</h3>
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>

--- a/src/endpoints/books/BooksView.tsx
+++ b/src/endpoints/books/BooksView.tsx
@@ -211,7 +211,7 @@ return (
 
     {/* Form panel (unchanged) */}
     {showForm && (
-      <div style={{ border: '1px solid #ddd', borderRadius: 8, padding: 12, marginBottom: 16, background: '#fafafa' }}>
+      <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
         <h3 style={{ marginTop: 0 }}>{editingId ? 'Edit Book' : 'New Book'}</h3>
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>

--- a/src/endpoints/poisons/PoisonsView.tsx
+++ b/src/endpoints/poisons/PoisonsView.tsx
@@ -232,7 +232,7 @@ return (
 
     {/* Form panel (unchanged) */}
     {showForm && (
-      <div style={{ border: '1px solid #ddd', borderRadius: 8, padding: 12, marginBottom: 16, background: '#fafafa' }}>
+      <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
         <h3 style={{ marginTop: 0 }}>{editingId ? 'Edit Poison' : 'New Poison'}</h3>
 
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>


### PR DESCRIPTION
This pull request updates the styling of form panels in several endpoint views to use CSS variables instead of hardcoded colors. This change ensures consistent theming across the application and makes it easier to maintain or update the look and feel.

Styling improvements for form panels:

* Replaced hardcoded border and background colors with CSS variables (`var(--border)` and `var(--panel)`) in `src/endpoints/armourtypes/ArmourtypesView.tsx` for the form panel.
* Updated the form panel in `src/endpoints/books/BooksView.tsx` to use CSS variables for border and background colors.
* Changed the form panel in `src/endpoints/poisons/PoisonsView.tsx` to use CSS variables for border and background colors.