### PR TITLE
Move api TypeScript definitios to dedicated api folder

### DIFF
--- a/src/api/armourtypes.ts
+++ b/src/api/armourtypes.ts
@@ -1,5 +1,5 @@
-import { fetchJson, sendJson } from '../../api/client';
-import type { Armourtype, ArmourtypesPayload } from '../../types';
+import { fetchJson, sendJson } from './client';
+import type { Armourtype, ArmourtypesPayload } from '../types';
 
 const BASE = '/rmce/objects/armourtype';
 

--- a/src/api/books.ts
+++ b/src/api/books.ts
@@ -1,5 +1,5 @@
-import { fetchJson, sendJson } from '../../api/client';
-import type { Book, BooksPayload } from '../../types';
+import { fetchJson, sendJson } from './client';
+import type { Book, BooksPayload } from '../types';
 
 const BASE = '/rmce/objects/book';
 

--- a/src/api/poisons.ts
+++ b/src/api/poisons.ts
@@ -1,5 +1,5 @@
-import { fetchJson, sendJson } from '../../api/client';
-import type { Poison, PoisonsPayload } from '../../types';
+import { fetchJson, sendJson } from './client';
+import type { Poison, PoisonsPayload } from '../types';
 
 const BASE = '/rmce/objects/poison';
 

--- a/src/endpoints/armourtypes/ArmourtypesView.tsx
+++ b/src/endpoints/armourtypes/ArmourtypesView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { DataTable, DataTableSearchInput, type ColumnDef } from '../../components/DataTable';
-import { fetchArmourtypes, upsertArmourtype, deleteArmourtype } from './api';
+import { fetchArmourtypes, upsertArmourtype, deleteArmourtype } from '../../api/armourtypes';
 import type { Armourtype } from '../../types';
 import { useConfirm } from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';

--- a/src/endpoints/books/BooksView.tsx
+++ b/src/endpoints/books/BooksView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { DataTable, DataTableSearchInput, type ColumnDef } from '../../components/DataTable';
-import { fetchBooks, upsertBook, deleteBook } from './api';
+import { fetchBooks, upsertBook, deleteBook } from '../../api/books';
 import type { Book } from '../../types';
 import { useConfirm } from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';

--- a/src/endpoints/poisons/PoisonsView.tsx
+++ b/src/endpoints/poisons/PoisonsView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { DataTable, DataTableSearchInput, type ColumnDef } from '../../components/DataTable'
-import { fetchPoisons, upsertPoison, deletePoison } from './api';
+import { fetchPoisons, upsertPoison, deletePoison } from '../../api/poisons';
 import type { Poison } from '../../types';
 import { useConfirm } from '../../components/ConfirmDialog';
 import { useToast } from '../../components/Toast';


### PR DESCRIPTION
This pull request refactors the API layer by moving and renaming files to improve project structure and maintainability. It also updates import paths in related view components to reflect these changes. The main themes are API file organization and updating component imports.

API file restructuring:

* Moved and renamed API files from `src/endpoints/[resource]/api.ts` to `src/api/[resource].ts`, updating their internal imports accordingly. (`src/api/armourtypes.ts` [[1]](diffhunk://#diff-0c39fe7e755015cc5d34266532732f8e3367bc0865e3f367931bad2727818f1dL1-R2) `src/api/books.ts` [[2]](diffhunk://#diff-01a4d441f5444e7225b28083aae034417698d4cb362b2e8703e3f745c2902785L1-R2) `src/api/poisons.ts` [[3]](diffhunk://#diff-60cfee7558a907d62aac58cd51ddf6d39cfff9952a3c1a9ded97647994069480L1-R2)

Component import updates:

* Updated `ArmourtypesView`, `BooksView`, and `PoisonsView` components to import API functions from the new locations in `src/api` instead of their previous local paths. (`src/endpoints/armourtypes/ArmourtypesView.tsx` [[1]](diffhunk://#diff-cf579bb1c309d30f531caf781528beec54782339c081b2369db3685eeccb7fecL3-R3) `src/endpoints/books/BooksView.tsx` [[2]](diffhunk://#diff-93dfdbe080c1c2be2bfc7f8905296aab045b5e1b9f6df05e4d8f4cc5c6d833f1L3-R3) `src/endpoints/poisons/PoisonsView.tsx` [[3]](diffhunk://#diff-bb29f296b459be0390a327a267d57c215efa94348f6d637a37017526debcf9bfL3-R3)