### PR TITLE
Refactor API method handling to use PUT for editing resources

### DIFF
--- a/src/endpoints/armourtypes/ArmourtypesView.tsx
+++ b/src/endpoints/armourtypes/ArmourtypesView.tsx
@@ -139,13 +139,13 @@ export default function ArmourtypesView() {
 
     const nextErrors = computeErrors(payload, Boolean(editingId));
     setErrors(nextErrors);
-    const topError = nextErrors.id || nextErrors.name || nextErrors.type || '';
+    const topError = nextErrors.id || nextErrors.name || nextErrors.type || nextErrors.numeric || '';
     if (topError) { setFormErr(topError); return; }
 
     const isEditing = Boolean(editingId);
     try {
       const opts = editingId
-        ? { method: 'POST' as const, useResourceIdPath: false } // or PUT+id if your API prefers
+        ? { method: 'PUT' as const, useResourceIdPath: true }
         : { method: 'POST' as const, useResourceIdPath: false };
 
       await upsertArmourtype(payload, opts);

--- a/src/endpoints/books/BooksView.tsx
+++ b/src/endpoints/books/BooksView.tsx
@@ -130,7 +130,7 @@ export default function BooksView() {
     try {
       // default POST to /rmce/objects/book/ with a single JSON object
       const opts = editingId
-        ? { method: 'POST' as const, useResourceIdPath: false }
+        ? { method: 'PUT' as const, useResourceIdPath: true }
         : { method: 'POST' as const, useResourceIdPath: false };
 
       await upsertBook(payload, opts);

--- a/src/endpoints/climates/ClimateView.tsx
+++ b/src/endpoints/climates/ClimateView.tsx
@@ -126,7 +126,7 @@ export default function ClimateView() {
     try {
       // Default edit → PUT /rmce/objects/climate/{id}; create → POST /rmce/objects/climate/
       const opts = isEditing
-        ? { method: 'POST' as const, useResourceIdPath: false } // ← use POST with body ID for upsert (simpler, and PUT with ID path can cause issues if ID is changed in future)
+        ? { method: 'PUT' as const, useResourceIdPath: true }
         : { method: 'POST' as const, useResourceIdPath: false };
 
       await upsertClimate(payload, opts);

--- a/src/endpoints/poisons/PoisonsView.tsx
+++ b/src/endpoints/poisons/PoisonsView.tsx
@@ -54,7 +54,7 @@ export default function PoisonsView() {
     else if (!isEditing && rows.some(r => r.id === draft.id.trim())) next.id = `ID "${draft.id.trim()}" already exists`;
     if (!draft.id.trim().toUpperCase().startsWith('POISON_')) next.id = 'ID must start with "POISON_"';
     if (!/^[A-Z0-9_]+$/.test(draft.id.trim())) next.id = 'ID can only contain uppercase letters, numbers and underscores';
-    if (draft.id.trim().length <= 11) next.id = 'ID must contain additional characters after "POISON_"';
+    if (draft.id.trim().length <= 7) next.id = 'ID must contain additional characters after "POISON_"';
     // Name
     if (!draft.name.trim()) next.name = 'Name is required';
     // Type
@@ -123,13 +123,13 @@ export default function PoisonsView() {
 
     const nextErrors = computeErrors(payload, Boolean(editingId));
     setErrors(nextErrors);
-    const topError = nextErrors.id || nextErrors.name || nextErrors.type || '';
+    const topError = nextErrors.id || nextErrors.name || nextErrors.type || nextErrors.level || nextErrors.variance || '';
     if (topError) { setFormErr(topError); return; }
 
     const isEditing = Boolean(editingId);
     try {
       const opts = editingId
-        ? { method: 'POST' as const, useResourceIdPath: false }
+        ? { method: 'PUT' as const, useResourceIdPath: true }
         : { method: 'POST' as const, useResourceIdPath: false };
 
       await upsertPoison(payload, opts);


### PR DESCRIPTION
This pull request updates the edit and upsert logic for several endpoint views to use the correct HTTP method and resource path for editing operations. It also improves error handling for form validation, ensuring more specific errors are surfaced to the user. The most important changes are grouped below by theme.

**API Method and Path Consistency:**

* Changed edit operations in `ArmourtypesView`, `BooksView`, `ClimateView`, and `PoisonsView` to use `PUT` requests with resource ID paths, instead of `POST` with IDs in the body. This aligns with RESTful conventions and ensures proper handling of updates. [[1]](diffhunk://#diff-cf579bb1c309d30f531caf781528beec54782339c081b2369db3685eeccb7fecL142-R148) [[2]](diffhunk://#diff-93dfdbe080c1c2be2bfc7f8905296aab045b5e1b9f6df05e4d8f4cc5c6d833f1L133-R133) [[3]](diffhunk://#diff-092866cc2b294b80feb18e7b534459a5963768961e09d4eed5fd88b3e61c1d5dL129-R129) [[4]](diffhunk://#diff-bb29f296b459be0390a327a267d57c215efa94348f6d637a37017526debcf9bfL126-R132)

**Form Validation Improvements:**

* Updated error aggregation in `ArmourtypesView` to include `numeric` field errors, so users receive more precise feedback when submitting invalid data.
* Enhanced error aggregation in `PoisonsView` to include `level` and `variance` errors, improving the clarity of form validation messages.
* Adjusted the minimum ID length validation in `PoisonsView` to require at least one character after "POISON_", fixing an off-by-one error in the previous logic.…multiple views