### PR TITLE
Add style for viewing forms

### DIFF
--- a/src/components/inputs/CheckboxGroup.tsx
+++ b/src/components/inputs/CheckboxGroup.tsx
@@ -122,7 +122,7 @@ export function CheckboxGroup<T extends string = string>({
       {...(error ? { 'aria-invalid': true } : {})}
       {...(required ? { 'aria-required': true } : {})}
       disabled={disabled}
-      style={{ margin: 0, padding: 0, border: 'none', minInlineSize: 0 }}
+      style={{ margin: 0, padding: 0, border: 'none', minInlineSize: 0, opacity: disabled ? 0.75 : 1, }}
     >
       <legend style={{ fontSize: 14, marginBottom: 6 }}>
         {label}{required ? ' *' : ''}

--- a/src/endpoints/armourtypes/ArmourtypesView.tsx
+++ b/src/endpoints/armourtypes/ArmourtypesView.tsx
@@ -270,7 +270,7 @@ export default function ArmourtypesView() {
 
       {/* Form panel (Create & Edit) */}
       {showForm && (
-        <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
+        <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`} style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
           <h3 style={{ marginTop: 0 }}>{editingId ? 'Edit Armour Type' : 'New Armour Type'}</h3>
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>

--- a/src/endpoints/books/BooksView.tsx
+++ b/src/endpoints/books/BooksView.tsx
@@ -121,15 +121,15 @@ export default function BooksView() {
       isbn: String(form.isbn).trim(),
     };
 
-    const nextErrors = computeErrors(payload, Boolean(editingId));
+    const isEditing = Boolean(editingId);
+    const nextErrors = computeErrors(payload, isEditing);
     setErrors(nextErrors);
     const topError = nextErrors.id || nextErrors.name || nextErrors.code || nextErrors.abbreviation || nextErrors.isbn || '';
     if (topError) { setFormErr(topError); return; }
 
-    const isEditing = Boolean(editingId);
     try {
       // default POST to /rmce/objects/book/ with a single JSON object
-      const opts = editingId
+      const opts = isEditing
         ? { method: 'PUT' as const, useResourceIdPath: true }
         : { method: 'POST' as const, useResourceIdPath: false };
 
@@ -250,7 +250,7 @@ export default function BooksView() {
 
       {/* Form panel (Create & Edit) */}
       {showForm && (
-        <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
+        <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`} style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
           <h3 style={{ marginTop: 0 }}>{editingId ? 'Edit Book' : 'New Book'}</h3>
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>

--- a/src/endpoints/climates/ClimateView.tsx
+++ b/src/endpoints/climates/ClimateView.tsx
@@ -288,7 +288,7 @@ export default function ClimateView() {
 
       {/* Form panel (Create & Edit) */}
       {showForm && (
-        <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
+        <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`} style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
           <h3 style={{ marginTop: 0 }}>{editingId ? 'Edit Climate' : 'New Climate'}</h3>
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>

--- a/src/endpoints/poisons/PoisonsView.tsx
+++ b/src/endpoints/poisons/PoisonsView.tsx
@@ -245,7 +245,7 @@ export default function PoisonsView() {
 
       {/* Form panel (Create & Edit) */}
       {showForm && (
-        <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
+        <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`} style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
           <h3 style={{ marginTop: 0 }}>{editingId ? 'Edit Poison' : 'New Poison'}</h3>
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>

--- a/src/endpoints/poisontypes/PoisontypesView.tsx
+++ b/src/endpoints/poisontypes/PoisontypesView.tsx
@@ -123,10 +123,17 @@ export default function PoisontypesView() {
     (errors.effectOnsets && SEVERITIES.some((s) => errors.effectOnsets?.[s])) ||
     (errors.symptoms && SEVERITIES.some((s) => errors.symptoms?.[s]))
   );
-  const computeErrors = (draft = form) => {
+  const computeErrors = (draft = form, isEditing: boolean) => {
     const e: typeof errors = {};
+    // ID
     if (!draft.id.trim()) e.id = 'ID is required';
+    else if (!isEditing && rows.some(r => r.id === draft.id.trim())) e.id = `ID "${draft.id.trim()}" already exists`;
+    if (!draft.id.trim().toUpperCase().startsWith('POISONTYPE_')) e.id = 'ID must start with "POISONTYPE_"';
+    if (!/^[A-Z0-9_]+$/.test(draft.id.trim())) e.id = 'ID can only contain uppercase letters, numbers and underscores';
+    if (draft.id.trim().length <= 12) e.id = 'ID must contain additional characters after "POISONTYPE_"';
+    // Type
     if (!draft.type.trim()) e.type = 'Type is required';
+    // Areas affected
     if (!draft.areasAffected.trim()) e.areasAffected = 'Areas affected is required';
 
     // Check we have exactly one row per known severity (we always build that, but double-check)
@@ -169,12 +176,12 @@ export default function PoisontypesView() {
     return e;
   };
 
-
   useEffect(() => {
     if (!showForm) return;
     if (viewing) return;               // suppress live errors while viewing
-    setErrors(computeErrors());
-  }, [form, showForm, viewing]);
+    const isEditing = Boolean(editingId);
+    setErrors(computeErrors(form, isEditing));
+  }, [form, showForm, editingId]); // keep current to avoid stale closure
 
   // ----- Actions -----
   const startNew = () => {
@@ -185,16 +192,16 @@ export default function PoisontypesView() {
     setShowForm(true);
   };
 
-  const startView = (row: PoisonType) => {
-    setViewing(true);
+  const startEdit = (row: PoisonType) => {
+    setViewing(false);
     setEditingId(row.id);
     setForm(toVM(row));
     setErrors({});
     setShowForm(true);
   };
 
-  const startEdit = (row: PoisonType) => {
-    setViewing(false);
+  const startView = (row: PoisonType) => {
+    setViewing(true);
     setEditingId(row.id);
     setForm(toVM(row));
     setErrors({});
@@ -209,16 +216,17 @@ export default function PoisontypesView() {
   };
 
   const saveForm = async () => {
-    const e = computeErrors(form);
+    const payload = fromVM(form);
+
+    const isEditing = Boolean(editingId);
+
+    const e = computeErrors(form, isEditing);
     setErrors(e);
     const firstTop =
       e.id || e.type || e.areasAffected ||
       (e.effectOnsets && SEVERITIES.map((s) => e.effectOnsets?.[s]).find(Boolean)) ||
       (e.symptoms && SEVERITIES.map((s) => e.symptoms?.[s]).find(Boolean)) || '';
     if (firstTop) return;
-
-    const payload = fromVM(form);
-    const isEditing = Boolean(editingId);
 
     try {
       const opts = isEditing
@@ -381,6 +389,7 @@ export default function PoisontypesView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rows]);
 
+  // ----- Search -----
   const globalFilter = (r: PoisonType, q: string) => {
     const s = q.toLowerCase();
     const hay = [
@@ -391,6 +400,7 @@ export default function PoisontypesView() {
     return hay.includes(s);
   };
 
+  // ----- Render -----
   if (loading) return <div>Loading…</div>;
   if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
 
@@ -411,7 +421,7 @@ export default function PoisontypesView() {
 
       {/* Form panel */}
       {showForm && (
-        <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
+        <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`} style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
           <h3 style={{ marginTop: 0 }}>
             {viewing ? 'View Poison Type' : (editingId ? 'Edit Poison Type' : 'New Poison Type')}
           </h3>

--- a/src/layout.css
+++ b/src/layout.css
@@ -319,3 +319,54 @@ tr:nth-child(even) {
 body.theme-dark tr:nth-child(even) {
   background: color-mix(in oklch, var(--bg), white 3%);
 }
+
+/* ===========================
+   Read-only / View Mode
+   =========================== */
+
+.form-panel--view {
+  background: color-mix(in oklch, var(--panel), var(--bg) 30%);
+}
+
+/* Shared visual style for disabled inputs in view mode */
+.form-panel--view input:disabled,
+.form-panel--view select:disabled,
+.form-panel--view textarea:disabled {
+  background: color-mix(in oklch, var(--bg), var(--panel) 70%);
+  color: var(--muted);
+  border-color: color-mix(in oklch, var(--border), var(--bg) 40%);
+  cursor: not-allowed;
+}
+
+/* Remove focus styles in view mode */
+.form-panel--view input:disabled:focus,
+.form-panel--view select:disabled:focus,
+.form-panel--view textarea:disabled:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+/* Checkbox & radio tweaks */
+.form-panel--view input[type="checkbox"]:disabled,
+.form-panel--view input[type="radio"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* Labels slightly muted */
+.form-panel--view label {
+  color: var(--muted);
+}
+
+/* Section headers still readable */
+.form-panel--view h3,
+.form-panel--view h4 {
+  color: var(--text);
+}
+
+/* Buttons: only Close should look active */
+.form-panel--view button:not(:enabled),
+.form-panel--view button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
This pull request introduces a new "view mode" for form panels across multiple endpoints, improving the user experience when displaying read-only data. It refactors the logic for editing and viewing forms, enhances error validation for poison types, and adds visual styles for disabled inputs in view mode.

View mode improvements:

* Added the `.form-panel--view` class to form panels in `BooksView`, `ArmourtypesView`, `ClimateView`, `PoisonsView`, and `PoisontypesView` to visually distinguish read-only forms. (`src/endpoints/books/BooksView.tsx` [[1]](diffhunk://#diff-93dfdbe080c1c2be2bfc7f8905296aab045b5e1b9f6df05e4d8f4cc5c6d833f1L253-R253) `src/endpoints/armourtypes/ArmourtypesView.tsx` [[2]](diffhunk://#diff-cf579bb1c309d30f531caf781528beec54782339c081b2369db3685eeccb7fecL273-R273) `src/endpoints/climates/ClimateView.tsx` [[3]](diffhunk://#diff-092866cc2b294b80feb18e7b534459a5963768961e09d4eed5fd88b3e61c1d5dL291-R291) `src/endpoints/poisons/PoisonsView.tsx` [[4]](diffhunk://#diff-bb29f296b459be0390a327a267d57c215efa94348f6d637a37017526debcf9bfL248-R248) `src/endpoints/poisontypes/PoisontypesView.tsx` [[5]](diffhunk://#diff-da6d71e03ebc4887bd372cae8c4e56965362e5b08e9d15953e397767a1a6fd54L414-R424)
* Added new CSS rules in `src/layout.css` for `.form-panel--view` to style disabled inputs, labels, buttons, and headers in view mode, making read-only panels visually distinct and improving accessibility.

Form logic and validation enhancements:

* Refactored `PoisontypesView` to improve error validation for IDs, including checks for uniqueness, required prefix, allowed characters, and minimum length.
* Updated form error computation and state management in `PoisontypesView` to properly handle edit vs. create modes and avoid stale closures. [[1]](diffhunk://#diff-da6d71e03ebc4887bd372cae8c4e56965362e5b08e9d15953e397767a1a6fd54L172-R184) [[2]](diffhunk://#diff-da6d71e03ebc4887bd372cae8c4e56965362e5b08e9d15953e397767a1a6fd54L212-L222)
* Swapped the logic for `startEdit` and `startView` functions in `PoisontypesView` to clarify mode handling and improve maintainability.

General UI improvements:

* Improved the disabled state appearance for checkboxes in `CheckboxGroup.tsx` by adjusting opacity when disabled.
* Minor refactor in `BooksView` to clarify edit vs. create logic and improve error handling.

These changes collectively enhance both the visual clarity and reliability of form panels, especially in read-only scenarios, while improving validation and code maintainability.