### PR TITLE
Add duplicate button on table

### DIFF
--- a/src/endpoints/armourtypes/ArmourtypesView.tsx
+++ b/src/endpoints/armourtypes/ArmourtypesView.tsx
@@ -106,6 +106,19 @@ export default function ArmourtypesView() {
     setShowForm(true);
   };
 
+  const startDuplicate = (row: Armourtype) => {
+    setViewing?.(false);           // if you have viewing state; otherwise omit
+    setEditingId(null);
+
+    const next = { ...row };
+    next.id = 'ARMOURTYPE_';
+    next.name += ' (Copy)';
+
+    setForm(next as any); // if your form state = Armourtype
+    setErrors?.({});      // if you have an errors object
+    setShowForm(true);
+  };
+
   const startView = (row: Armourtype) => {
     setViewing(true);
     setEditingId(row.id);       // we can reuse editingId to preload the item, but we won't allow saving
@@ -113,7 +126,8 @@ export default function ArmourtypesView() {
     setErrors({});              // no need to compute field errors for read-only view, but we can keep formErr for any potential top-level messages
     setFormErr('');
     setShowForm(true);
-  }
+  };
+
   const cancelForm = () => {
     setViewing(false);
     setShowForm(false);
@@ -230,6 +244,7 @@ export default function ArmourtypesView() {
           <>
             <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
             <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+            <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
             <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
           </>
         ),

--- a/src/endpoints/books/BooksView.tsx
+++ b/src/endpoints/books/BooksView.tsx
@@ -95,6 +95,20 @@ export default function BooksView() {
     setShowForm(true);
   };
 
+  const startDuplicate = (row: Book) => {
+    setViewing(false);
+    setEditingId(null);
+
+    const next = { ...row };
+    next.id = 'BOOK_';
+    next.name += ' (Copy)';
+    next.isbn = ''; // Clear ISBN to force user to enter a new one, since it must be unique
+
+    setForm(next);
+    setErrors({});
+    setShowForm(true);
+  };
+
   const startView = (row: Book) => {
     setViewing(true);
     setEditingId(row.id);       // we can reuse editingId to preload the item, but we won't allow saving
@@ -213,6 +227,7 @@ export default function BooksView() {
           <>
             <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
             <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+            <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
             <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
           </>
         ),

--- a/src/endpoints/climates/ClimateView.tsx
+++ b/src/endpoints/climates/ClimateView.tsx
@@ -92,6 +92,19 @@ export default function ClimateView() {
     setShowForm(true);
   };
 
+  const startDuplicate = (row: Climate) => {
+    setViewing(false);
+    setEditingId(null);
+
+    const vm = { ...row }; // your Climate form already uses domain type as form state
+    vm.id = 'CLIMATE_';
+    vm.name += ' (Copy)';
+
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+
   const startView = (row: Climate) => {
     setViewing(true);
     setEditingId(row.id);       // we can reuse editingId to preload the item, but we won't allow saving
@@ -99,7 +112,7 @@ export default function ClimateView() {
     setErrors({});              // no need to compute field errors for read-only view, but we can keep formErr for any potential top-level messages
     setFormErr('');
     setShowForm(true);
-  }
+  };
 
   const cancelForm = () => {
     setViewing(false);
@@ -248,6 +261,7 @@ export default function ClimateView() {
           <>
             <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
             <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+            <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
             <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
           </>
         ),

--- a/src/endpoints/poisons/PoisonsView.tsx
+++ b/src/endpoints/poisons/PoisonsView.tsx
@@ -94,6 +94,19 @@ export default function PoisonsView() {
     setShowForm(true);
   };
 
+  const startDuplicate = (row: Poison) => {
+    setViewing(false);
+    setEditingId(null);
+
+    const next = { ...row };
+    next.id = 'POISON_';
+    next.name += ' (Copy)';
+
+    setForm(next); // if your form state = Poison
+    setErrors?.({});      // if you have an errors object
+    setShowForm(true);
+  };
+
   const startView = (row: Poison) => {
     setViewing(true);
     setEditingId(row.id);       // we can reuse editingId to preload the item, but we won't allow saving
@@ -101,7 +114,7 @@ export default function PoisonsView() {
     setErrors({});              // no need to compute field errors for read-only view, but we can keep formErr for any potential top-level messages
     setFormErr('');
     setShowForm(true);
-  }
+  };
 
   const cancelForm = () => {
     setViewing(false);
@@ -209,6 +222,7 @@ export default function PoisonsView() {
           <>
             <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
             <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+            <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
             <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
           </>
         ),

--- a/src/endpoints/poisontypes/PoisontypesView.tsx
+++ b/src/endpoints/poisontypes/PoisontypesView.tsx
@@ -200,6 +200,18 @@ export default function PoisontypesView() {
     setShowForm(true);
   };
 
+  const startDuplicate = (row: PoisonType) => {
+    setViewing(false);
+    setEditingId(null);
+    // Create a copy of the row 
+    const vm = toVM(row);
+    vm.id = 'POISONTYPE_'; // Set the ID to a default value that the user must change
+    vm.type += ' (Copy)'; // Append " (Copy)" to the type for clarity
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+
   const startView = (row: PoisonType) => {
     setViewing(true);
     setEditingId(row.id);
@@ -381,6 +393,7 @@ export default function PoisontypesView() {
           <>
             <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
             <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+            <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
             <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
           </>
         ),


### PR DESCRIPTION
This pull request adds a "Duplicate" functionality to several entity views in the application, allowing users to quickly create a copy of an existing item with some fields modified for clarity and uniqueness. The duplicate action is now available alongside View, Edit, and Delete actions for each row in the affected views.

**Duplicate feature additions:**

* Added a `startDuplicate` function to each of the following views: `ArmourtypesView`, `BooksView`, `ClimateView`, `PoisonsView`, and `PoisontypesView`. This function creates a copy of the selected row, modifies the ID and name/type fields, and opens the form for editing the new item. [[1]](diffhunk://#diff-cf579bb1c309d30f531caf781528beec54782339c081b2369db3685eeccb7fecR109-R130) [[2]](diffhunk://#diff-93dfdbe080c1c2be2bfc7f8905296aab045b5e1b9f6df05e4d8f4cc5c6d833f1R98-R111) [[3]](diffhunk://#diff-092866cc2b294b80feb18e7b534459a5963768961e09d4eed5fd88b3e61c1d5dR95-R115) [[4]](diffhunk://#diff-bb29f296b459be0390a327a267d57c215efa94348f6d637a37017526debcf9bfR97-R117) [[5]](diffhunk://#diff-da6d71e03ebc4887bd372cae8c4e56965362e5b08e9d15953e397767a1a6fd54R203-R214)

**UI enhancements:**

* Added a "Duplicate" button to the row actions in each of the affected views, enabling users to initiate the duplication process directly from the list. [[1]](diffhunk://#diff-cf579bb1c309d30f531caf781528beec54782339c081b2369db3685eeccb7fecR247) [[2]](diffhunk://#diff-93dfdbe080c1c2be2bfc7f8905296aab045b5e1b9f6df05e4d8f4cc5c6d833f1R230) [[3]](diffhunk://#diff-092866cc2b294b80feb18e7b534459a5963768961e09d4eed5fd88b3e61c1d5dR264) [[4]](diffhunk://#diff-bb29f296b459be0390a327a267d57c215efa94348f6d637a37017526debcf9bfR225) [[5]](diffhunk://#diff-da6d71e03ebc4887bd372cae8c4e56965362e5b08e9d15953e397767a1a6fd54R396)

**Entity-specific logic:**

* In `BooksView`, the ISBN field is cleared in the duplicated item to ensure uniqueness and require user input.
* In `PoisontypesView`, the duplication uses a `toVM` conversion and appends " (Copy)" to the `type` field for clarity.

These changes improve usability by streamlining the process of creating similar items and ensuring that duplicated records are clearly marked and require unique identifiers.