### PR TITLE
Add SkillGroup handling

### DIFF
--- a/src/api/skillgroup.ts
+++ b/src/api/skillgroup.ts
@@ -1,0 +1,38 @@
+import { fetchJson, sendJson } from './client';
+import type { SkillGroup, SkillGroupsPayload } from '../types/skillgroup';
+
+const BASE = '/rmce/objects/skillgroup';
+
+function asString(v: unknown): string {
+  return String(v ?? '');
+}
+
+/** GET /rmce/objects/skillgroup → { skillgroups: SkillGroup[] } */
+export async function fetchSkillgroups(): Promise<SkillGroup[]> {
+  const data = await fetchJson<SkillGroupsPayload>(BASE);
+  if (!data || !Array.isArray((data as any).skillgroups)) {
+    throw new Error('Unexpected response: expected { skillgroups: [...] }');
+  }
+  return (data as SkillGroupsPayload).skillgroups.map(s => ({
+    id: asString(s.id),
+    name: asString(s.name),
+  }));
+}
+
+/** Create or update a single skill group. */
+export async function upsertSkillgroup(
+  sg: SkillGroup,
+  opts: { method?: 'POST' | 'PUT'; useResourceIdPath?: boolean } = {},
+): Promise<unknown> {
+  const { method = 'POST', useResourceIdPath = false } = opts;
+  const url = useResourceIdPath && sg?.id
+    ? `${BASE}/${encodeURIComponent(sg.id)}`
+    : `${BASE}/`;
+  return sendJson(url, method, sg);
+}
+
+/** DELETE /rmce/objects/skillgroup/{id} */
+export async function deleteSkillgroup(id: string): Promise<void> {
+  if (!id) throw new Error('deleteSkillgroup: id is required');
+  await fetchJson<void>(`${BASE}/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}

--- a/src/endpoints/skillgroup/SkillGroupView.tsx
+++ b/src/endpoints/skillgroup/SkillGroupView.tsx
@@ -1,0 +1,298 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { DataTable, DataTableSearchInput, type ColumnDef } from '../../components/DataTable';
+import { LabeledInput } from '../../components/inputs';
+import { useToast } from '../../components/Toast';
+import { useConfirm } from '../../components/ConfirmDialog';
+
+import { fetchSkillgroups, upsertSkillgroup, deleteSkillgroup } from '../../api/skillgroup';
+import type { SkillGroup } from '../../types/skillgroup';
+
+// ------------------------
+// Form VM (simple: same as domain)
+// ------------------------
+type FormState = {
+  id: string;
+  name: string;
+};
+
+function emptyVM(): FormState {
+  return { id: 'SKILLGROUP_', name: '' };
+}
+function toVM(s: SkillGroup): FormState {
+  return { id: s.id, name: s.name };
+}
+function fromVM(vm: FormState): SkillGroup {
+  return { id: vm.id.trim(), name: vm.name.trim() };
+}
+
+export default function SkillGroupView() {
+  const [rows, setRows] = useState<SkillGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [viewing, setViewing] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyVM());
+  const [errors, setErrors] = useState<{ id?: string | undefined; name?: string | undefined }>({});
+
+  const toast = useToast();
+  const confirm = useConfirm();
+
+  // ---- Load ----
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const list = await fetchSkillgroups();
+        if (!mounted) return;
+        setRows(list);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  // ---- Validation ----
+  const computeErrors = (draft = form) => {
+    const e: typeof errors = {};
+    if (!draft.id.trim()) e.id = 'ID is required';
+    else if (!editingId && rows.some(r => r.id === draft.id.trim())) e.id = `ID "${draft.id.trim()}" already exists`;
+    else if (!draft.id.trim().toUpperCase().startsWith('SKILLGROUP_')) e.id = 'ID must start with "SKILLGROUP_"';
+    else if (draft.id.trim().length <= 11) e.id = 'ID must contain additional characters after "SKILLGROUP_"';
+    else if (!/^[A-Z0-9_]+$/.test(draft.id.trim())) e.id = 'ID can only contain uppercase letters, numbers and underscores';
+
+    if (!draft.name.trim()) e.name = 'Name is required';
+    return e;
+  };
+  const hasErrors = Boolean(errors.id || errors.name);
+
+  useEffect(() => {
+    if (!showForm || viewing) return;
+    setErrors(computeErrors());
+  }, [form, showForm, viewing]);
+
+  // ---- Actions ----
+  const startNew = () => {
+    setViewing(false);
+    setEditingId(null);
+    setForm(emptyVM());
+    setErrors({});
+    setShowForm(true);
+  };
+  const startView = (row: SkillGroup) => {
+    setViewing(true);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+  const startEdit = (row: SkillGroup) => {
+    setViewing(false);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+  const startDuplicate = (row: SkillGroup) => {
+    setViewing(false);
+    setEditingId(null);
+    const vm = toVM(row);
+    const ids = new Set(rows.map(r => r.id));
+    vm.id = 'SKILLGROUP_';
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+  const cancelForm = () => {
+    setShowForm(false);
+    setViewing(false);
+    setEditingId(null);
+    setErrors({});
+  };
+
+  const saveForm = async () => {
+    const e = computeErrors(form);
+    setErrors(e);
+    const top = e.id || e.name || '';
+    if (top) return;
+
+    const payload = fromVM(form);
+    const isEditing = Boolean(editingId);
+    try {
+      const opts = isEditing
+        ? { method: 'PUT' as const, useResourceIdPath: true }
+        : { method: 'POST' as const, useResourceIdPath: false };
+      await upsertSkillgroup(payload, opts);
+
+      setRows(prev => {
+        if (isEditing) {
+          const idx = prev.findIndex(r => r.id === payload.id);
+          if (idx >= 0) {
+            const copy = [...prev];
+            copy[idx] = { ...copy[idx], ...payload };
+            return copy;
+          }
+          return [payload, ...prev];
+        }
+        return [payload, ...prev];
+      });
+
+      setShowForm(false);
+      setViewing(false);
+      setEditingId(null);
+      toast({
+        variant: 'success',
+        title: isEditing ? 'Updated' : 'Saved',
+        description: `Skill group "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
+      });
+    } catch (err) {
+      toast({
+        variant: 'danger',
+        title: 'Save failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    }
+  };
+
+  const onDelete = async (row: SkillGroup) => {
+    const ok = await confirm({
+      title: 'Delete Skill Group',
+      body: `Delete skill group "${row.id}"? This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    const prev = rows;
+    setRows(prev.filter(r => r.id !== row.id));
+    try {
+      await deleteSkillgroup(row.id);
+      if (editingId === row.id || viewing) cancelForm();
+      toast({ variant: 'success', title: 'Deleted', description: `Skill group "${row.id}" deleted.` });
+    } catch (err) {
+      setRows(prev);
+      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err) });
+    }
+  };
+
+  // ---- Table ----
+  const columns: ColumnDef<SkillGroup>[] = useMemo(() => [
+    { id: 'id', header: 'id', accessor: r => r.id, sortType: 'string', minWidth: 260 },
+    { id: 'name', header: 'name', accessor: r => r.name, sortType: 'string', minWidth: 180 },
+    {
+      id: 'actions',
+      header: 'actions',
+      sortable: false,
+      width: 300,
+      render: (row) => (
+        <>
+          <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
+          <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+          <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
+          <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
+        </>
+      ),
+    },
+  ], []);
+
+  const globalFilter = (r: SkillGroup, q: string) => {
+    const s = q.toLowerCase();
+    return [r.id, r.name].some(v => String(v ?? '').toLowerCase().includes(s));
+  };
+
+  if (loading) return <div>Loading…</div>;
+  if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
+
+  return (
+    <>
+      <h2>Skill Groups</h2>
+
+      {/* Toolbar hidden while form is visible */}
+      {!showForm && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '12px 0' }}>
+          <button onClick={startNew}>New Skill Group</button>
+          <DataTableSearchInput
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search skill groups…"
+            aria-label="Search skill groups"
+          />
+        </div>
+      )}
+
+      {/* Form panel */}
+      {showForm && (
+        <div
+          className={`form-panel ${viewing ? 'form-panel--view' : ''}`}
+          style={{
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: 12,
+            marginBottom: 16,
+            background: 'var(--panel)',
+          }}
+        >
+          <h3 style={{ marginTop: 0 }}>
+            {viewing ? 'View Skill Group' : (editingId ? 'Edit Skill Group' : 'New Skill Group')}
+          </h3>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <LabeledInput
+              label="ID"
+              value={form.id}
+              onChange={(v) => setForm(s => ({ ...s, id: v }))}
+              disabled={!!editingId || viewing}
+              error={viewing ? undefined : errors.id}
+            />
+            <LabeledInput
+              label="Name"
+              value={form.name}
+              onChange={(v) => setForm(s => ({ ...s, name: v }))}
+              disabled={viewing}
+              error={viewing ? undefined : errors.name}
+            />
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+            {!viewing && <button onClick={saveForm} disabled={hasErrors}>Save</button>}
+            <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
+          </div>
+        </div>
+      )}
+
+      {/* Table hidden while form up */}
+      {!showForm && (
+        <DataTable<SkillGroup>
+          rows={rows}
+          columns={columns}
+          rowId={(r) => r.id}
+          initialSort={{ colId: 'name', dir: 'asc' }}
+          searchQuery={query}
+          globalFilter={globalFilter}
+          mode="client"
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          pageSizeOptions={[5, 10, 20, 50, 100]}
+          tableMinWidth={700}
+          zebra
+          hover
+          resizable
+          persistKey="dt.skillgroup.v1"
+          ariaLabel="Skill groups"
+        />
+      )}
+    </>
+  );
+}

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -8,6 +8,7 @@ const DiseaseView = lazy(() => import('../endpoints/disease/DiseaseView'));
 const DiseaseTypeView = lazy(() => import('../endpoints/diseasetype/DiseaseTypeView'));
 const PoisonView = lazy(() => import('../endpoints/poison/PoisonView'));
 const PoisonTypeView = lazy(() => import('../endpoints/poisontype/PoisonTypeView'));
+const SkillGroupView = lazy(() => import('../endpoints/skillgroup/SkillGroupView'));
 const SpellListView = lazy(() => import('../endpoints/spelllist/SpellListView'));
 
 
@@ -29,6 +30,7 @@ const known: Record<string, ResourceDef> = {
   diseasetype: { prefix: 'diseasetype', label: 'Disease Types', path: '/diseasetypes', Component: DiseaseTypeView },
   poison: { prefix: 'poison', label: 'Poisons', path: '/poisons', Component: PoisonView },
   poisontype: { prefix: 'poisontype', label: 'Poison Types', path: '/poisontypes', Component: PoisonTypeView },
+  skillgroup: { prefix: 'skillgroup', label: 'Skill Groups', path: '/skillgroups', Component: SkillGroupView },
   spelllist: { prefix: 'spelllist', label: 'Spell Lists', path: '/spelllists', Component: SpellListView },
 }
 
@@ -55,5 +57,6 @@ export const FALLBACK_RESOURCES: ResourceDef[] = [
   known.diseasetype,
   known.poison,
   known.poisontype,
+  known.skillgroup,
   known.spelllist,
 ].filter((r): r is ResourceDef => Boolean(r));

--- a/src/types/skillgroup.ts
+++ b/src/types/skillgroup.ts
@@ -1,0 +1,11 @@
+// ------------------------
+// Skill Groups
+// ------------------------
+export interface SkillGroup {
+  id: string;
+  name: string;
+}
+
+export interface SkillGroupsPayload {
+  skillgroups: SkillGroup[];
+}


### PR DESCRIPTION
This pull request introduces a new "Skill Group" resource to the application, including its API integration, type definitions, and a full-featured UI view for managing skill groups. The implementation covers CRUD operations, validation, and integration into the resource registry.

**Skill Group resource integration:**

* Added a new API module `src/api/skillgroup.ts` with functions for fetching, creating/updating, and deleting skill groups, including response validation and error handling.
* Defined new types in `src/types/skillgroup.ts` for `SkillGroup` and the payload structure returned from the backend.

**UI and resource registry updates:**

* Implemented a new view component `src/endpoints/skillgroup/SkillGroupView.tsx` with a table, search, and form for skill group CRUD operations, including validation, duplication, and user feedback.
* Registered the Skill Group resource in `src/resources/registry.ts` for routing, lazy loading, and inclusion in fallback resources. [[1]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R11) [[2]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R33) [[3]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R60)