### PR TITLE
Add LanguageCategory handling

### DIFF
--- a/src/api/languagecategory.ts
+++ b/src/api/languagecategory.ts
@@ -1,0 +1,36 @@
+import { fetchJson, sendJson } from './client';
+import type { LanguageCategory, LanguageCategoriesPayload } from '../types/languagecategory';
+
+const BASE = '/rmce/objects/languagecategory';
+
+const asString = (v: unknown) => String(v ?? '');
+
+/** GET /rmce/objects/languagecategory → { languagecategories: LanguageCategory[] } */
+export async function fetchLanguagecategories(): Promise<LanguageCategory[]> {
+  const data = await fetchJson<LanguageCategoriesPayload>(BASE);
+  if (!data || !Array.isArray((data as any).languagecategories)) {
+    throw new Error('Unexpected response: expected { languagecategories: [...] }');
+  }
+  return (data as LanguageCategoriesPayload).languagecategories.map((x) => ({
+    id: asString(x.id),
+    name: asString(x.name),
+  }));
+}
+
+/** Create or update a single language category. */
+export async function upsertLanguagecategory(
+  lc: LanguageCategory,
+  opts: { method?: 'POST' | 'PUT'; useResourceIdPath?: boolean } = {},
+) {
+  const { method = 'POST', useResourceIdPath = false } = opts;
+  const url = useResourceIdPath && lc?.id
+    ? `${BASE}/${encodeURIComponent(lc.id)}`
+    : `${BASE}/`;
+  return sendJson(url, method, lc);
+}
+
+/** DELETE /rmce/objects/languagecategory/{id} */
+export async function deleteLanguagecategory(id: string) {
+  if (!id) throw new Error('deleteLanguagecategory: id is required');
+  await fetchJson<void>(`${BASE}/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}

--- a/src/endpoints/languagecategory/LanguageCategoryView.tsx
+++ b/src/endpoints/languagecategory/LanguageCategoryView.tsx
@@ -1,0 +1,294 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { DataTable, DataTableSearchInput, type ColumnDef } from '../../components/DataTable';
+import { LabeledInput } from '../../components/inputs';
+import { useToast } from '../../components/Toast';
+import { useConfirm } from '../../components/ConfirmDialog';
+
+import { fetchLanguagecategories, upsertLanguagecategory, deleteLanguagecategory } from '../../api/languagecategory';
+
+import type { LanguageCategory } from '../../types/languagecategory';
+
+// --- Form VM (same shape) ---
+type FormState = { id: string; name: string };
+
+const emptyVM = (): FormState => ({ id: 'LANGUAGECATEGORY_', name: '' });
+const toVM = (x: LanguageCategory): FormState => ({ id: x.id, name: x.name });
+const fromVM = (vm: FormState): LanguageCategory => ({ id: vm.id.trim(), name: vm.name.trim() });
+
+
+
+export default function LanguageCategoryView() {
+  const [rows, setRows] = useState<LanguageCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [viewing, setViewing] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyVM());
+  const [errors, setErrors] = useState<{ id?: string | undefined; name?: string | undefined }>({});
+
+  const toast = useToast();
+  const confirm = useConfirm();
+
+  // ---- Load ----
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const list = await fetchLanguagecategories();
+        if (!mounted) return;
+        setRows(list);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  // ---- Validation ----
+  const computeErrors = (draft = form) => {
+    const e: typeof errors = {};
+    // ID rules:
+    if (!draft.id.trim()) e.id = 'ID is required';
+    else if (!draft.id.trim().toUpperCase().startsWith('LANGUAGECATEGORY_')) e.id = 'ID must start with "LANGUAGECATEGORY_"';
+    else if (draft.id.trim().length <= 17) e.id = 'ID must contain additional characters after "LANGUAGECATEGORY_"';
+    else if (!/^[A-Z0-9_]+$/.test(draft.id.trim())) e.id = 'ID can only contain uppercase letters, numbers and underscores';
+    else if (!editingId && rows.some(r => r.id === draft.id.trim())) e.id = `ID "${draft.id.trim()}" already exists`;
+    // Name rules:
+    if (!draft.name.trim()) e.name = 'Name is required';
+
+    return e;
+  };
+  const hasErrors = Boolean(errors.id || errors.name);
+
+  useEffect(() => {
+    if (!showForm || viewing) return;
+    setErrors(computeErrors());
+  }, [form, showForm, viewing]);
+
+  // ---- Actions ----
+  const startNew = () => {
+    setViewing(false);
+    setEditingId(null);
+    setForm(emptyVM());
+    setErrors({});
+    setShowForm(true);
+  };
+  const startView = (row: LanguageCategory) => {
+    setViewing(true);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+  const startEdit = (row: LanguageCategory) => {
+    setViewing(false);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+  const startDuplicate = (row: LanguageCategory) => {
+    setViewing(false);
+    setEditingId(null);
+    const vm = toVM(row);
+    vm.id = 'LANGUAGECATEGORY_';
+    vm.name += ' (Copy)';
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+  const cancelForm = () => {
+    setShowForm(false);
+    setViewing(false);
+    setEditingId(null);
+    setErrors({});
+  };
+
+  const saveForm = async () => {
+    const e = computeErrors(form);
+    setErrors(e);
+    const top = e.id || e.name || '';
+    if (top) return;
+
+    const payload = fromVM(form);
+    const isEditing = Boolean(editingId);
+
+    try {
+      const opts = isEditing
+        ? { method: 'PUT' as const, useResourceIdPath: true }
+        : { method: 'POST' as const, useResourceIdPath: false };
+
+      await upsertLanguagecategory(payload, opts);
+
+      setRows(prev => {
+        if (isEditing) {
+          const idx = prev.findIndex(r => r.id === payload.id);
+          if (idx >= 0) {
+            const copy = [...prev];
+            copy[idx] = { ...copy[idx], ...payload };
+            return copy;
+          }
+          return [payload, ...prev];
+        }
+        return [payload, ...prev];
+      });
+
+      setShowForm(false);
+      setViewing(false);
+      setEditingId(null);
+      toast({
+        variant: 'success',
+        title: isEditing ? 'Updated' : 'Saved',
+        description: `Language category "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
+      });
+    } catch (err) {
+      toast({
+        variant: 'danger',
+        title: 'Save failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    }
+  };
+
+  const onDelete = async (row: LanguageCategory) => {
+    const ok = await confirm({
+      title: 'Delete Language Category',
+      body: `Delete language category "${row.id}"? This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    const prev = rows;
+    setRows(prev.filter(r => r.id !== row.id));
+    try {
+      await deleteLanguagecategory(row.id);
+      if (editingId === row.id || viewing) cancelForm();
+      toast({ variant: 'success', title: 'Deleted', description: `Language category "${row.id}" deleted.` });
+    } catch (err) {
+      setRows(prev);
+      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err) });
+    }
+  };
+
+  // ---- Table ----
+  const columns: ColumnDef<LanguageCategory>[] = useMemo(() => [
+    { id: 'id', header: 'id', accessor: r => r.id, sortType: 'string', minWidth: 260 },
+    { id: 'name', header: 'name', accessor: r => r.name, sortType: 'string', minWidth: 180 },
+    {
+      id: 'actions',
+      header: 'actions',
+      sortable: false,
+      width: 300,
+      render: (row) => (
+        <>
+          <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
+          <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+          <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
+          <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
+        </>
+      ),
+    },
+  ], []);
+
+  const globalFilter = (r: LanguageCategory, q: string) => {
+    const s = q.toLowerCase();
+    return [r.id, r.name].some(v => String(v ?? '').toLowerCase().includes(s));
+  };
+
+  if (loading) return <div>Loading…</div>;
+  if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
+
+  return (
+    <>
+      <h2>Language Categories</h2>
+
+      {/* Toolbar hidden while form is visible */}
+      {!showForm && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '12px 0' }}>
+          <button onClick={startNew}>New Language Category</button>
+          <DataTableSearchInput
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search language categories…"
+            aria-label="Search language categories"
+          />
+        </div>
+      )}
+
+      {/* Form panel */}
+      {showForm && (
+        <div
+          className={`form-panel ${viewing ? 'form-panel--view' : ''}`}
+          style={{
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            padding: 12,
+            marginBottom: 16,
+            background: 'var(--panel)',
+          }}
+        >
+          <h3 style={{ marginTop: 0 }}>
+            {viewing ? 'View Language Category' : (editingId ? 'Edit Language Category' : 'New Language Category')}
+          </h3>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <LabeledInput
+              label="ID"
+              value={form.id}
+              onChange={(v) => setForm(s => ({ ...s, id: v }))}
+              disabled={!!editingId || viewing}
+              error={viewing ? undefined : errors.id}
+            />
+            <LabeledInput
+              label="Name"
+              value={form.name}
+              onChange={(v) => setForm(s => ({ ...s, name: v }))}
+              disabled={viewing}
+              error={viewing ? undefined : errors.name}
+            />
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+            {!viewing && <button onClick={saveForm} disabled={hasErrors}>Save</button>}
+            <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
+          </div>
+        </div>
+      )}
+
+      {/* Table hidden while form up */}
+      {!showForm && (
+        <DataTable<LanguageCategory>
+          rows={rows}
+          columns={columns}
+          rowId={(r) => r.id}
+          initialSort={{ colId: 'name', dir: 'asc' }}
+          searchQuery={query}
+          globalFilter={globalFilter}
+          mode="client"
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          pageSizeOptions={[5, 10, 20, 50, 100]}
+          tableMinWidth={700}
+          zebra
+          hover
+          resizable
+          persistKey="dt.languagecategory.v1"
+          ariaLabel="Language categories"
+        />
+      )}
+    </>
+  );
+}

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -6,6 +6,7 @@ const ClimateView = lazy(() => import('../endpoints/climate/ClimateView'));
 const CreaturePaceView = lazy(() => import('../endpoints/creaturepace/CreaturePaceView'));
 const DiseaseView = lazy(() => import('../endpoints/disease/DiseaseView'));
 const DiseaseTypeView = lazy(() => import('../endpoints/diseasetype/DiseaseTypeView'));
+const LanguageCategoryView = lazy(() => import('../endpoints/languagecategory/LanguageCategoryView'));
 const PoisonView = lazy(() => import('../endpoints/poison/PoisonView'));
 const PoisonTypeView = lazy(() => import('../endpoints/poisontype/PoisonTypeView'));
 const SkillGroupView = lazy(() => import('../endpoints/skillgroup/SkillGroupView'));
@@ -28,6 +29,7 @@ const known: Record<string, ResourceDef> = {
   creaturepace: { prefix: 'creaturepace', label: 'Creature Paces', path: '/creaturepaces', Component: CreaturePaceView },
   disease: { prefix: 'disease', label: 'Diseases', path: '/diseases', Component: DiseaseView },
   diseasetype: { prefix: 'diseasetype', label: 'Disease Types', path: '/diseasetypes', Component: DiseaseTypeView },
+  languagecategory: { prefix: 'languagecategory', label: 'Language Categories', path: '/languagecategories', Component: LanguageCategoryView },
   poison: { prefix: 'poison', label: 'Poisons', path: '/poisons', Component: PoisonView },
   poisontype: { prefix: 'poisontype', label: 'Poison Types', path: '/poisontypes', Component: PoisonTypeView },
   skillgroup: { prefix: 'skillgroup', label: 'Skill Groups', path: '/skillgroups', Component: SkillGroupView },
@@ -55,6 +57,7 @@ export const FALLBACK_RESOURCES: ResourceDef[] = [
   known.creaturepace,
   known.disease,
   known.diseasetype,
+  known.languagecategory,
   known.poison,
   known.poisontype,
   known.skillgroup,

--- a/src/types/languagecategory.ts
+++ b/src/types/languagecategory.ts
@@ -1,0 +1,11 @@
+// ------------------------
+// Language Categories
+// ------------------------
+export interface LanguageCategory {
+  id: string;
+  name: string;
+}
+
+export interface LanguageCategoriesPayload {
+  languagecategories: LanguageCategory[];
+}


### PR DESCRIPTION
This pull request introduces a new "Language Category" resource to the application, including API integration, type definitions, and a full-featured UI view for managing language categories. The changes are organized into three main themes: API and type support, UI implementation, and resource registry integration.

**API and Type Support**

* Added `src/api/languagecategory.ts` with functions to fetch, create/update, and delete language categories via the backend API.
* Defined new TypeScript interfaces in `src/types/languagecategory.ts` for `LanguageCategory` and the API payload structure.

**UI Implementation**

* Created `src/endpoints/languagecategory/LanguageCategoryView.tsx`, a React component providing a table view, search, and CRUD operations (create, edit, duplicate, delete, view) for language categories, including validation and user feedback.

**Resource Registry Integration**

* Registered the new resource in `src/resources/registry.ts`, including lazy loading, route definition, and fallback resource listing for navigation and discovery. [[1]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R9) [[2]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R32) [[3]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R60)