### PR TITLE
Add Language handling

### DIFF
--- a/src/api/language.ts
+++ b/src/api/language.ts
@@ -1,0 +1,42 @@
+import { fetchJson, sendJson } from './client';
+import type { Language, LanguagesPayload } from '../types/language';
+
+const BASE = '/rmce/objects/language';
+
+const asString = (v: unknown) => String(v ?? '');
+const asBool = (v: unknown) => v === true || v === 'true' || v === 1 || v === '1';
+
+/** GET /rmce/objects/language → { languages: Language[] } */
+export async function fetchLanguages(): Promise<Language[]> {
+  const data = await fetchJson<LanguagesPayload>(BASE);
+  if (!data || !Array.isArray((data as any).languages)) {
+    throw new Error('Unexpected response: expected { languages: [...] }');
+  }
+  return (data as LanguagesPayload).languages.map((x) => ({
+    id: asString(x.id),
+    name: asString(x.name),
+    category: asString(x.category),
+    baseLanguage: x.baseLanguage != null ? asString(x.baseLanguage) : undefined,
+    isSpoken: asBool((x as any).isSpoken),
+    isWritten: asBool((x as any).isWritten),
+    isSomantic: asBool((x as any).isSomantic),
+  }));
+}
+
+/** Create or update a single language. */
+export async function upsertLanguage(
+  lang: Language,
+  opts: { method?: 'POST' | 'PUT'; useResourceIdPath?: boolean } = {},
+) {
+  const { method = 'POST', useResourceIdPath = false } = opts;
+  const url = useResourceIdPath && lang?.id
+    ? `${BASE}/${encodeURIComponent(lang.id)}`
+    : `${BASE}/`;
+  return sendJson(url, method, lang);
+}
+
+/** DELETE /rmce/objects/language/{id} */
+export async function deleteLanguage(id: string) {
+  if (!id) throw new Error('deleteLanguage: id is required');
+  await fetchJson<void>(`${BASE}/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}

--- a/src/endpoints/language/LanguageView.tsx
+++ b/src/endpoints/language/LanguageView.tsx
@@ -1,0 +1,461 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { DataTable, DataTableSearchInput, type ColumnDef } from '../../components/DataTable';
+import { LabeledInput, LabeledSelect } from '../../components/inputs';
+import { useToast } from '../../components/Toast';
+import { useConfirm } from '../../components/ConfirmDialog';
+
+import { fetchLanguages, upsertLanguage, deleteLanguage } from '../../api/language';
+import { fetchLanguagecategories } from '../../api/languagecategory';
+import type { Language } from '../../types/language';
+import type { LanguageCategory } from '../../types/languagecategory';
+
+// ------------------------
+// Form VM (strings for inputs, booleans as booleans)
+// ------------------------
+type FormState = {
+  id: string;
+  name: string;
+  category: string;
+  baseLanguage?: string | undefined;
+  isSpoken: boolean;
+  isWritten: boolean;
+  isSomantic: boolean;
+};
+
+const emptyVM = (): FormState => ({
+  id: 'LANGUAGE_',
+  name: '',
+  category: '',
+  baseLanguage: '',
+  isSpoken: false,
+  isWritten: false,
+  isSomantic: false,
+});
+
+const toVM = (x: Language): FormState => ({
+  id: x.id,
+  name: x.name,
+  category: x.category,
+  baseLanguage: x.baseLanguage ?? '',
+  isSpoken: x.isSpoken,
+  isWritten: x.isWritten,
+  isSomantic: x.isSomantic,
+});
+
+const fromVM = (vm: FormState): Language => ({
+  id: vm.id.trim(),
+  name: vm.name.trim(),
+  category: vm.category.trim(),
+  baseLanguage: vm.baseLanguage?.trim() ? vm.baseLanguage.trim() : undefined,
+  isSpoken: !!vm.isSpoken,
+  isWritten: !!vm.isWritten,
+  isSomantic: !!vm.isSomantic,
+});
+
+/** Local Fix‑A checkbox wrapper */
+function LabeledCheckbox({
+  label,
+  checked,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (val: boolean) => void;
+  disabled?: boolean | undefined;
+}) {
+  const id = React.useId();
+  return (
+    <label htmlFor={id} style={{ display: 'inline-flex', alignItems: 'center', gap: 8, paddingTop: 6 }}>
+      <input id={id} type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} disabled={disabled} />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+export default function LanguagesView() {
+  const [rows, setRows] = useState<Language[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [categories, setCategories] = useState<LanguageCategory[]>([]);
+  const [catLoading, setCatLoading] = useState(true);
+
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [viewing, setViewing] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyVM());
+  const [errors, setErrors] = useState<{
+    id?: string | undefined;
+    name?: string | undefined;
+    category?: string | undefined;
+  }>({});
+
+  const toast = useToast();
+  const confirm = useConfirm();
+
+  // ---- Load languages ----
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const list = await fetchLanguages();
+        if (!mounted) return;
+        setRows(list);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  // ---- Load categories (for select + table labels) ----
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const list = await fetchLanguagecategories();
+        if (!mounted) return;
+        setCategories(list);
+      } catch (e) {
+        console.error('Failed to load LanguageCategories', e);
+      } finally {
+        if (mounted) setCatLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  // ---- Category maps/options ----
+  const categoryNameById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of categories) m.set(c.id, c.name);
+    return m;
+  }, [categories]);
+
+  const categoryOptions = useMemo(
+    () => categories.map((c) => ({ value: c.id, label: `${c.name}` })),
+    [categories]
+  );
+
+  // ---- Validation ----
+  const computeErrors = (draft = form) => {
+    const e: typeof errors = {};
+    if (!draft.id.trim()) e.id = 'ID is required';
+    else if (!draft.id.trim().toUpperCase().startsWith('LANGUAGE_')) e.id = 'ID must start with "LANGUAGE_"';
+    else if (draft.id.trim().length <= 9) e.id = 'ID must contain additional characters after "LANGUAGE_"';
+    else if (!/^[A-Z0-9_]+$/.test(draft.id.trim())) e.id = 'ID can only contain uppercase letters, numbers and underscores';
+    if (!draft.name.trim()) e.name = 'Name is required';
+
+    const cat = draft.category.trim();
+    if (!cat) e.category = 'Category is required';
+    else if (!categoryNameById.has(cat)) e.category = 'Category must be a valid LanguageCategory ID';
+
+    // uniqueness (create only)
+    if (!editingId && rows.some((r) => r.id === draft.id.trim())) {
+      e.id = `ID "${draft.id.trim()}" already exists`;
+    }
+    return e;
+  };
+
+  const hasErrors = Boolean(errors.id || errors.name || errors.category);
+
+  useEffect(() => {
+    if (!showForm || viewing) return;
+    setErrors(computeErrors());
+  }, [form, showForm, viewing, categoryNameById]);
+
+  // ---- Actions ----
+  const startNew = () => {
+    setViewing(false);
+    setEditingId(null);
+    setForm(emptyVM());
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startView = (row: Language) => {
+    setViewing(true);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startEdit = (row: Language) => {
+    setViewing(false);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startDuplicate = (row: Language) => {
+    setViewing(false);
+    setEditingId(null);
+    const vm = toVM(row);
+    vm.id = 'LANGUAGE_';
+    vm.name += ' (copy)';
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const cancelForm = () => {
+    setShowForm(false);
+    setViewing(false);
+    setEditingId(null);
+    setErrors({});
+  };
+
+  const saveForm = async () => {
+    const e = computeErrors(form);
+    setErrors(e);
+    const top = e.id || e.name || e.category || '';
+    if (top) return;
+
+    const payload = fromVM(form);
+    const isEditing = Boolean(editingId);
+    try {
+      const opts = isEditing
+        ? { method: 'PUT' as const, useResourceIdPath: true }
+        : { method: 'POST' as const, useResourceIdPath: false };
+      await upsertLanguage(payload, opts);
+
+      setRows((prev) => {
+        if (isEditing) {
+          const idx = prev.findIndex((r) => r.id === payload.id);
+          if (idx >= 0) {
+            const copy = [...prev];
+            copy[idx] = { ...copy[idx], ...payload };
+            return copy;
+          }
+          return [payload, ...prev];
+        }
+        return [payload, ...prev];
+      });
+
+      setShowForm(false);
+      setViewing(false);
+      setEditingId(null);
+      toast({
+        variant: 'success',
+        title: isEditing ? 'Updated' : 'Saved',
+        description: `Language "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
+      });
+    } catch (err) {
+      toast({
+        variant: 'danger',
+        title: 'Save failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    }
+  };
+
+  const onDelete = async (row: Language) => {
+    const ok = await confirm({
+      title: 'Delete Language',
+      body: `Delete language "${row.id}"? This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    const prev = rows;
+    setRows(prev.filter((r) => r.id !== row.id));
+    try {
+      await deleteLanguage(row.id);
+      if (editingId === row.id || viewing) cancelForm();
+      toast({ variant: 'success', title: 'Deleted', description: `Language "${row.id}" deleted.` });
+    } catch (err) {
+      setRows(prev);
+      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err) });
+    }
+  };
+
+  // ---- Table ----
+  const columns: ColumnDef<Language>[] = useMemo(() => [
+    { id: 'id', header: 'id', accessor: (r) => r.id, sortType: 'string', minWidth: 260 },
+    { id: 'name', header: 'name', accessor: (r) => r.name, sortType: 'string', minWidth: 160 },
+    {
+      id: 'category',
+      header: 'category',
+      accessor: (r) => categoryNameById.get(r.category) ?? r.category, // sort by label fallback to id
+      sortType: 'string',
+      minWidth: 100,
+      render: (r) => {
+        const label = categoryNameById.get(r.category);
+        return label ? `${label}` : r.category;
+      },
+    },
+    {
+      id: 'baseLanguage',
+      header: 'baseLanguage',
+      accessor: (r) => r.baseLanguage ?? '',
+      sortType: 'string',
+      minWidth: 160,
+    },
+    {
+      id: 'isSpoken',
+      header: 'spoken',
+      accessor: (r) => Number(r.isSpoken),
+      sortType: 'number',
+      minWidth: 90,
+      render: (r) => (r.isSpoken ? 'Yes' : 'No'),
+    },
+    {
+      id: 'isWritten',
+      header: 'written',
+      accessor: (r) => Number(r.isWritten),
+      sortType: 'number',
+      minWidth: 90,
+      render: (r) => (r.isWritten ? 'Yes' : 'No'),
+    },
+    {
+      id: 'isSomantic',
+      header: 'somantic',
+      accessor: (r) => Number(r.isSomantic),
+      sortType: 'number',
+      minWidth: 100,
+      render: (r) => (r.isSomantic ? 'Yes' : 'No'),
+    },
+    {
+      id: 'actions',
+      header: 'actions',
+      sortable: false,
+      width: 340,
+      render: (row) => (
+        <>
+          <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
+          <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+          <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
+          <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
+        </>
+      ),
+    },
+    // 👇 ensure columns recompute when category labels arrive
+  ], [categoryNameById]);
+
+  const globalFilter = (r: Language, q: string) => {
+    const s = q.toLowerCase();
+    const catLabel = categoryNameById.get(r.category) ?? '';
+    return [
+      r.id, r.name, r.category, catLabel,
+      r.baseLanguage ?? '',
+      r.isSpoken ? 'yes' : 'no',
+      r.isWritten ? 'yes' : 'no',
+      r.isSomantic ? 'yes' : 'no',
+    ].some((v) => String(v ?? '').toLowerCase().includes(s));
+  };
+
+  if (loading) return <div>Loading…</div>;
+  if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
+
+  return (
+    <>
+      <h2>Languages</h2>
+
+      {/* Toolbar hidden while form visible */}
+      {!showForm && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '12px 0' }}>
+          <button onClick={startNew}>New Language</button>
+          <DataTableSearchInput
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search languages…"
+            aria-label="Search languages"
+          />
+        </div>
+      )}
+
+      {/* Form panel */}
+      {showForm && (
+        <div
+          className={`form-panel ${viewing ? 'form-panel--view' : ''}`}
+          style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}
+        >
+          <h3 style={{ marginTop: 0 }}>
+            {viewing ? 'View Language' : (editingId ? 'Edit Language' : 'New Language')}
+          </h3>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <LabeledInput
+              label="ID"
+              value={form.id}
+              onChange={(v) => setForm((s) => ({ ...s, id: v }))}
+              disabled={!!editingId || viewing}
+              error={viewing ? undefined : errors.id}
+            />
+            <LabeledInput
+              label="Name"
+              value={form.name}
+              onChange={(v) => setForm((s) => ({ ...s, name: v }))}
+              disabled={viewing}
+              error={viewing ? undefined : errors.name}
+            />
+
+            <LabeledSelect
+              label="Category"
+              value={form.category}
+              onChange={(v) => setForm((s) => ({ ...s, category: v }))}
+              options={categoryOptions}
+              disabled={catLoading || viewing}
+              error={viewing ? undefined : errors.category}
+              helperText={catLoading ? 'Loading categories…' : 'Select a LanguageCategory id'}
+            />
+
+            <LabeledInput
+              label="Base Language (optional)"
+              value={form.baseLanguage ?? ''}
+              onChange={(v) => setForm((s) => ({ ...s, baseLanguage: v }))}
+              disabled={viewing}
+            />
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
+              <LabeledCheckbox label="Spoken" checked={form.isSpoken} onChange={(c) => setForm((s) => ({ ...s, isSpoken: c }))} disabled={viewing} />
+              <LabeledCheckbox label="Written" checked={form.isWritten} onChange={(c) => setForm((s) => ({ ...s, isWritten: c }))} disabled={viewing} />
+              <LabeledCheckbox label="Somantic" checked={form.isSomantic} onChange={(c) => setForm((s) => ({ ...s, isSomantic: c }))} disabled={viewing} />
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+            {!viewing && <button onClick={saveForm} disabled={hasErrors}>Save</button>}
+            <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
+          </div>
+        </div>
+      )}
+
+      {/* Table hidden while form up */}
+      {!showForm && (
+        <DataTable<Language>
+          rows={rows}
+          columns={columns}
+          rowId={(r) => r.id}
+          initialSort={{ colId: 'name', dir: 'asc' }}
+          searchQuery={query}
+          globalFilter={globalFilter}
+          mode="client"
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          pageSizeOptions={[5, 10, 20, 50, 100]}
+          tableMinWidth={900}
+          zebra
+          hover
+          resizable
+          persistKey="dt.language.v1"
+          ariaLabel="Languages"
+        />
+      )}
+    </>
+  );
+}

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -6,6 +6,7 @@ const ClimateView = lazy(() => import('../endpoints/climate/ClimateView'));
 const CreaturePaceView = lazy(() => import('../endpoints/creaturepace/CreaturePaceView'));
 const DiseaseView = lazy(() => import('../endpoints/disease/DiseaseView'));
 const DiseaseTypeView = lazy(() => import('../endpoints/diseasetype/DiseaseTypeView'));
+const LanguageView = lazy(() => import('../endpoints/language/LanguageView'));
 const LanguageCategoryView = lazy(() => import('../endpoints/languagecategory/LanguageCategoryView'));
 const PoisonView = lazy(() => import('../endpoints/poison/PoisonView'));
 const PoisonTypeView = lazy(() => import('../endpoints/poisontype/PoisonTypeView'));
@@ -29,6 +30,7 @@ const known: Record<string, ResourceDef> = {
   creaturepace: { prefix: 'creaturepace', label: 'Creature Paces', path: '/creaturepaces', Component: CreaturePaceView },
   disease: { prefix: 'disease', label: 'Diseases', path: '/diseases', Component: DiseaseView },
   diseasetype: { prefix: 'diseasetype', label: 'Disease Types', path: '/diseasetypes', Component: DiseaseTypeView },
+  language: { prefix: 'language', label: 'Languages', path: '/languages', Component: LanguageView },
   languagecategory: { prefix: 'languagecategory', label: 'Language Categories', path: '/languagecategories', Component: LanguageCategoryView },
   poison: { prefix: 'poison', label: 'Poisons', path: '/poisons', Component: PoisonView },
   poisontype: { prefix: 'poisontype', label: 'Poison Types', path: '/poisontypes', Component: PoisonTypeView },
@@ -57,6 +59,7 @@ export const FALLBACK_RESOURCES: ResourceDef[] = [
   known.creaturepace,
   known.disease,
   known.diseasetype,
+  known.language,
   known.languagecategory,
   known.poison,
   known.poisontype,

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,0 +1,18 @@
+// ------------------------
+// Languages
+// ------------------------
+export interface Language {
+  id: string;
+  name: string;
+  /** Reference to LanguageCategory.id */
+  category: string;
+  /** Optional free-text (e.g., "Common") */
+  baseLanguage?: string | undefined;
+  isSpoken: boolean;
+  isWritten: boolean;
+  isSomantic: boolean;
+}
+
+export interface LanguagesPayload {
+  languages: Language[];
+}


### PR DESCRIPTION
This pull request introduces support for managing languages in the application. The main changes include implementing API functions for language operations, defining the `Language` type, and registering the language resource in the application's resource registry.

Language API and Type Definitions:

* Added a new `src/api/language.ts` module with functions to fetch, create/update, and delete languages using the backend API.
* Defined the `Language` interface and related payload types in `src/types/language.ts`.

Resource Registry Integration:

* Registered the `LanguageView` component for lazy loading and added the language resource to the `known` resources map in `src/resources/registry.ts`. [[1]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R9) [[2]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R33)
* Included the language resource in the `FALLBACK_RESOURCES` array for default resource listing.