### PR TITLE
Add SkillProgressionType handling

### DIFF
--- a/src/api/skillprogressiontype.ts
+++ b/src/api/skillprogressiontype.ts
@@ -1,0 +1,42 @@
+import { fetchJson, sendJson } from './client';
+import type { SkillProgressionType, SkillProgressionTypesPayload } from '../types/skillprogressiontype';
+
+const BASE = '/rmce/objects/skillprogressiontype';
+
+function asInt(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.trunc(n) : NaN;
+}
+const asString = (v: unknown) => String(v ?? '');
+
+export async function fetchSkillprogressiontypes(): Promise<SkillProgressionType[]> {
+  const data = await fetchJson<SkillProgressionTypesPayload>(BASE);
+  if (!data || !Array.isArray((data as any).skillprogressiontypes)) {
+    throw new Error('Unexpected response: expected { skillprogressiontypes: [...] }');
+  }
+  return (data as SkillProgressionTypesPayload).skillprogressiontypes.map((x) => ({
+    id: asString(x.id),
+    name: asString(x.name),
+    zero: asInt(x.zero),
+    ten: asInt(x.ten),
+    twenty: asInt(x.twenty),
+    thirty: asInt(x.thirty),
+    remaining: asInt(x.remaining),
+  }));
+}
+
+export async function upsertSkillprogressiontype(
+  spt: SkillProgressionType,
+  opts: { method?: 'POST' | 'PUT'; useResourceIdPath?: boolean } = {},
+): Promise<unknown> {
+  const { method = 'POST', useResourceIdPath = false } = opts;
+  const url = useResourceIdPath && spt?.id
+    ? `${BASE}/${encodeURIComponent(spt.id)}`
+    : `${BASE}/`;
+  return sendJson(url, method, spt);
+}
+
+export async function deleteSkillprogressiontype(id: string): Promise<void> {
+  if (!id) throw new Error('deleteSkillprogressiontype: id is required');
+  await fetchJson<void>(`${BASE}/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}

--- a/src/endpoints/skillprogressiontype/SkillProgressionTypeView.tsx
+++ b/src/endpoints/skillprogressiontype/SkillProgressionTypeView.tsx
@@ -1,0 +1,405 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { DataTable, DataTableSearchInput, type ColumnDef } from '../../components/DataTable';
+import { LabeledInput } from '../../components/inputs';
+import { useToast } from '../../components/Toast';
+import { useConfirm } from '../../components/ConfirmDialog';
+
+import {
+  fetchSkillprogressiontypes,
+  upsertSkillprogressiontype,
+  deleteSkillprogressiontype,
+} from '../../api/skillprogressiontype';
+import type { SkillProgressionType } from '../../types/skillprogressiontype';
+
+/* ------------------------
+   Form VM (use strings for number inputs while typing)
+------------------------- */
+type FormState = {
+  id: string;
+  name: string;
+  zero: string;
+  ten: string;
+  twenty: string;
+  thirty: string;
+  remaining: string;
+};
+
+const emptyVM = (): FormState => ({
+  id: 'SKILLPROGRESSIONTYPE_',
+  name: '',
+  zero: '',
+  ten: '',
+  twenty: '',
+  thirty: '',
+  remaining: '',
+});
+
+const toVM = (x: SkillProgressionType): FormState => ({
+  id: x.id,
+  name: x.name,
+  zero: String(x.zero),
+  ten: String(x.ten),
+  twenty: String(x.twenty),
+  thirty: String(x.thirty),
+  remaining: String(x.remaining),
+});
+
+const fromVM = (vm: FormState): SkillProgressionType => ({
+  id: vm.id.trim(),
+  name: vm.name.trim(),
+  zero: Number(vm.zero),
+  ten: Number(vm.ten),
+  twenty: Number(vm.twenty),
+  thirty: Number(vm.thirty),
+  remaining: Number(vm.remaining),
+});
+
+// integer-only sanitizer
+const INT_RE = /^[+-]?\d+$/;
+const sanitizeInt = (s: string) => s.replace(/[^0-9+\-]/g, '');
+
+export default function SkillProgressionTypeView() {
+  const [rows, setRows] = useState<SkillProgressionType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [viewing, setViewing] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyVM());
+  const [errors, setErrors] = useState<{
+    id?: string | undefined;
+    name?: string | undefined;
+    zero?: string | undefined;
+    ten?: string | undefined;
+    twenty?: string | undefined;
+    thirty?: string | undefined;
+    remaining?: string | undefined;
+  }>({});
+
+  const toast = useToast();
+  const confirm = useConfirm();
+
+  /* ---- Load ---- */
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const list = await fetchSkillprogressiontypes();
+        if (!mounted) return;
+        setRows(list);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  /* ---- Validation ---- */
+  const computeErrors = (draft = form) => {
+    const e: typeof errors = {};
+    if (!draft.id.trim()) e.id = 'ID is required';
+    else if (!draft.id.trim().toUpperCase().startsWith('SKILLPROGRESSIONTYPE_')) e.id = 'ID must start with "SKILLPROGRESSIONTYPE_"';
+    else if (draft.id.trim().length <= 21) e.id = 'ID must contain additional characters after "SKILLPROGRESSIONTYPE_"';
+    else if (!/^[A-Z0-9_]+$/.test(draft.id.trim())) e.id = 'ID can only contain uppercase letters, numbers and underscores';
+    if (!draft.name.trim()) e.name = 'Name is required';
+
+    const checkInt = (label: keyof FormState) => {
+      const v = (draft[label] ?? '').trim();
+      if (!v) e[label] = `${label} is required`;
+      else if (!INT_RE.test(v)) e[label] = `${label} must be an integer`;
+    };
+
+    checkInt('zero');
+    checkInt('ten');
+    checkInt('twenty');
+    checkInt('thirty');
+    checkInt('remaining');
+
+    // uniqueness (create only)
+    if (!editingId && rows.some(r => r.id === draft.id.trim())) {
+      e.id = `ID "${draft.id.trim()}" already exists`;
+    }
+    return e;
+  };
+
+  const hasErrors = Boolean(
+    errors.id || errors.name || errors.zero || errors.ten || errors.twenty || errors.thirty || errors.remaining
+  );
+
+  useEffect(() => {
+    if (!showForm || viewing) return;
+    setErrors(computeErrors());
+  }, [form, showForm, viewing]);
+
+  /* ---- Actions ---- */
+  const startNew = () => {
+    setViewing(false);
+    setEditingId(null);
+    setForm(emptyVM());
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startView = (row: SkillProgressionType) => {
+    setViewing(true);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startEdit = (row: SkillProgressionType) => {
+    setViewing(false);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startDuplicate = (row: SkillProgressionType) => {
+    setViewing(false);
+    setEditingId(null);
+    const vm = toVM(row);
+    const ids = new Set(rows.map(r => r.id));
+    vm.id = 'SKILLPROGRESSIONTYPE_';
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const cancelForm = () => {
+    setShowForm(false);
+    setViewing(false);
+    setEditingId(null);
+    setErrors({});
+  };
+
+  const saveForm = async () => {
+    const e = computeErrors(form);
+    setErrors(e);
+    const top = e.id || e.name || e.zero || e.ten || e.twenty || e.thirty || e.remaining || '';
+    if (top) return;
+
+    const payload = fromVM(form);
+    const isEditing = Boolean(editingId);
+    try {
+      const opts = isEditing
+        ? { method: 'PUT' as const, useResourceIdPath: true }
+        : { method: 'POST' as const, useResourceIdPath: false };
+      await upsertSkillprogressiontype(payload, opts);
+
+      setRows(prev => {
+        if (isEditing) {
+          const idx = prev.findIndex(r => r.id === payload.id);
+          if (idx >= 0) {
+            const copy = [...prev];
+            copy[idx] = { ...copy[idx], ...payload };
+            return copy;
+          }
+          return [payload, ...prev];
+        }
+        return [payload, ...prev];
+      });
+
+      setShowForm(false);
+      setViewing(false);
+      setEditingId(null);
+      toast({
+        variant: 'success',
+        title: isEditing ? 'Updated' : 'Saved',
+        description: `Skill progression type "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
+      });
+    } catch (err) {
+      toast({
+        variant: 'danger',
+        title: 'Save failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    }
+  };
+
+  const onDelete = async (row: SkillProgressionType) => {
+    const ok = await confirm({
+      title: 'Delete Skill Progression Type',
+      body: `Delete "${row.id}"? This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    const prev = rows;
+    setRows(prev.filter(r => r.id !== row.id));
+    try {
+      await deleteSkillprogressiontype(row.id);
+      if (editingId === row.id || viewing) cancelForm();
+      toast({ variant: 'success', title: 'Deleted', description: `Skill progression type "${row.id}" deleted.` });
+    } catch (err) {
+      setRows(prev);
+      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err) });
+    }
+  };
+
+  /* ---- Columns / Table ---- */
+  const columns: ColumnDef<SkillProgressionType>[] = useMemo(() => [
+    { id: 'id', header: 'id', accessor: r => r.id, sortType: 'string', minWidth: 350 },
+    { id: 'name', header: 'name', accessor: r => r.name, sortType: 'string', minWidth: 180 },
+    { id: 'zero', header: '0–9', accessor: r => r.zero, sortType: 'number', align: 'center', minWidth: 90, },
+    { id: 'ten', header: '10–19', accessor: r => r.ten, sortType: 'number', align: 'center', minWidth: 90, },
+    { id: 'twenty', header: '20–29', accessor: r => r.twenty, sortType: 'number', align: 'center', minWidth: 90, },
+    { id: 'thirty', header: '30–39', accessor: r => r.thirty, sortType: 'number', align: 'center', minWidth: 90, },
+    { id: 'remaining', header: '40+', accessor: r => r.remaining, sortType: 'number', align: 'center', minWidth: 90, },
+    {
+      id: 'actions', header: 'actions', sortable: false, width: 360,
+      render: (row) => (
+        <>
+          <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
+          <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+          <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
+          <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
+        </>
+      ),
+    },
+  ], []);
+
+  const globalFilter = (r: SkillProgressionType, q: string) => {
+    const s = q.toLowerCase();
+    return [
+      r.id, r.name,
+      r.zero, r.ten, r.twenty, r.thirty, r.remaining,
+    ].some(v => String(v ?? '').toLowerCase().includes(s));
+  };
+
+  if (loading) return <div>Loading…</div>;
+  if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
+
+  return (
+    <>
+      <h2>Skill Progression Types</h2>
+
+      {/* Toolbar hidden while form visible */}
+      {!showForm && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '12px 0' }}>
+          <button onClick={startNew}>New Skill Progression Type</button>
+          <DataTableSearchInput
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search skill progression types…"
+            aria-label="Search skill progression types"
+          />
+        </div>
+      )}
+
+      {/* Form panel */}
+      {showForm && (
+        <div
+          className={`form-panel ${viewing ? 'form-panel--view' : ''}`}
+          style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}
+        >
+          <h3 style={{ marginTop: 0 }}>
+            {viewing ? 'View Skill Progression Type' : (editingId ? 'Edit Skill Progression Type' : 'New Skill Progression Type')}
+          </h3>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <LabeledInput
+              label="ID"
+              value={form.id}
+              onChange={(v) => setForm(s => ({ ...s, id: v }))}
+              disabled={!!editingId || viewing}
+              error={viewing ? undefined : errors.id}
+            />
+            <LabeledInput
+              label="Name"
+              value={form.name}
+              onChange={(v) => setForm(s => ({ ...s, name: v }))}
+              disabled={viewing}
+              error={viewing ? undefined : errors.name}
+            />
+
+            <LabeledInput
+              label="0–9 (zero)"
+              value={form.zero}
+              onChange={(v) => setForm(s => ({ ...s, zero: sanitizeInt(v) }))}
+              disabled={viewing}
+              inputProps={{ inputMode: 'numeric', pattern: '^[+\\-]?\\d+$' }}
+              error={viewing ? undefined : errors.zero}
+            />
+
+            <LabeledInput
+              label="10–19 (ten)"
+              value={form.ten}
+              onChange={(v) => setForm(s => ({ ...s, ten: sanitizeInt(v) }))}
+              disabled={viewing}
+              inputProps={{ inputMode: 'numeric', pattern: '^[+\\-]?\\d+$' }}
+              error={viewing ? undefined : errors.ten}
+            />
+
+            <LabeledInput
+              label="20–29 (twenty)"
+              value={form.twenty}
+              onChange={(v) => setForm(s => ({ ...s, twenty: sanitizeInt(v) }))}
+              disabled={viewing}
+              inputProps={{ inputMode: 'numeric', pattern: '^[+\\-]?\\d+$' }}
+              error={viewing ? undefined : errors.twenty}
+            />
+
+            <LabeledInput
+              label="30–39 (thirty)"
+              value={form.thirty}
+              onChange={(v) => setForm(s => ({ ...s, thirty: sanitizeInt(v) }))}
+              disabled={viewing}
+              inputProps={{ inputMode: 'numeric', pattern: '^[+\\-]?\\d+$' }}
+              error={viewing ? undefined : errors.thirty}
+            />
+
+            <LabeledInput
+              label="40+ (remaining)"
+              value={form.remaining}
+              onChange={(v) => setForm(s => ({ ...s, remaining: sanitizeInt(v) }))}
+              disabled={viewing}
+              inputProps={{ inputMode: 'numeric', pattern: '^[+\\-]?\\d+$' }}
+              error={viewing ? undefined : errors.remaining}
+            />
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+            {!viewing && <button onClick={saveForm} disabled={hasErrors}>Save</button>}
+            <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
+          </div>
+        </div>
+      )}
+
+      {/* Table hidden while form visible */}
+      {!showForm && (
+        <DataTable<SkillProgressionType>
+          rows={rows}
+          columns={columns}
+          rowId={(r) => r.id}
+          initialSort={{ colId: 'name', dir: 'asc' }}
+          searchQuery={query}
+          globalFilter={globalFilter}
+          mode="client"
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          pageSizeOptions={[5, 10, 20, 50, 100]}
+          tableMinWidth={900}
+          zebra
+          hover
+          resizable
+          persistKey="dt.skillprogressiontype.v1"
+          ariaLabel="Skill progression types"
+        />
+      )}
+    </>
+  );
+}

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -11,6 +11,7 @@ const LanguageCategoryView = lazy(() => import('../endpoints/languagecategory/La
 const PoisonView = lazy(() => import('../endpoints/poison/PoisonView'));
 const PoisonTypeView = lazy(() => import('../endpoints/poisontype/PoisonTypeView'));
 const SkillGroupView = lazy(() => import('../endpoints/skillgroup/SkillGroupView'));
+const SkillProgressionTypeView = lazy(() => import('../endpoints/skillprogressiontype/SkillProgressionTypeView'));
 const SpellListView = lazy(() => import('../endpoints/spelllist/SpellListView'));
 
 
@@ -35,6 +36,7 @@ const known: Record<string, ResourceDef> = {
   poison: { prefix: 'poison', label: 'Poisons', path: '/poisons', Component: PoisonView },
   poisontype: { prefix: 'poisontype', label: 'Poison Types', path: '/poisontypes', Component: PoisonTypeView },
   skillgroup: { prefix: 'skillgroup', label: 'Skill Groups', path: '/skillgroups', Component: SkillGroupView },
+  skillprogressiontype: { prefix: 'skillprogressiontype', label: 'Skill Progression Types', path: '/skillprogressiontypes', Component: SkillProgressionTypeView },
   spelllist: { prefix: 'spelllist', label: 'Spell Lists', path: '/spelllists', Component: SpellListView },
 }
 
@@ -64,5 +66,6 @@ export const FALLBACK_RESOURCES: ResourceDef[] = [
   known.poison,
   known.poisontype,
   known.skillgroup,
+  known.skillprogressiontype,
   known.spelllist,
 ].filter((r): r is ResourceDef => Boolean(r));

--- a/src/types/skillprogressiontype.ts
+++ b/src/types/skillprogressiontype.ts
@@ -1,0 +1,17 @@
+// ------------------------
+// Skill Progression Types
+// ------------------------
+export interface SkillProgressionType {
+  id: string;
+  name: string;
+  /** Development point costs at ranks: 0–9, 10–19, 20–29, 30–39, and remaining (40+) */
+  zero: number;
+  ten: number;
+  twenty: number;
+  thirty: number;
+  remaining: number;
+}
+
+export interface SkillProgressionTypesPayload {
+  skillprogressiontypes: SkillProgressionType[];
+}


### PR DESCRIPTION
This pull request adds support for "Skill Progression Types" as a new resource in the application. The changes include introducing API functions, types, and registry entries to handle this resource, enabling fetching, creating/updating, and deleting skill progression types.

**Skill Progression Type resource support:**

* Added a new API module `src/api/skillprogressiontype.ts` with functions to fetch, upsert, and delete skill progression types, including input validation and response mapping.
* Defined new TypeScript interfaces in `src/types/skillprogressiontype.ts` for `SkillProgressionType` and its payload, specifying the structure and expected fields.

**Resource registry integration:**

* Registered the `SkillProgressionTypeView` component for lazy loading in `src/resources/registry.ts` to enable UI routing for the new resource.
* Added `skillprogressiontype` to the known resources and fallback resources in the registry, ensuring it appears in resource listings and navigation. [[1]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R39) [[2]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R69)