### PR TITLE
Add TreasureCode handling

### DIFF
--- a/src/api/treasurecode.ts
+++ b/src/api/treasurecode.ts
@@ -1,0 +1,45 @@
+import { fetchJson, sendJson } from './client';
+import type { TreasureCode, TreasureCodesPayload } from '../types/treasurecode';
+import { TREASUREVALUETYPES, type TreasureValueType } from '../types/enum';
+
+const BASE = '/rmce/objects/treasurecode';
+
+const asString = (v: unknown) => String(v ?? '');
+
+function asTreasureValueType(v: unknown): TreasureValueType {
+  const s = asString(v);
+  return (TREASUREVALUETYPES as readonly string[]).includes(s)
+    ? (s as TreasureValueType)
+    : 'Normal'; // fallback if server ever sends an unknown value
+}
+
+/** GET /rmce/objects/treasurecode → { treasurecodes: TreasureCode[] } */
+export async function fetchTreasurecodes(): Promise<TreasureCode[]> {
+  const data = await fetchJson<TreasureCodesPayload>(BASE);
+  if (!data || !Array.isArray((data as any).treasurecodes)) {
+    throw new Error('Unexpected response: expected { treasurecodes: [...] }');
+  }
+  return (data as TreasureCodesPayload).treasurecodes.map((x) => ({
+    id: asString(x.id),
+    itemsValueType: asTreasureValueType(x.itemsValueType),
+    wealthValueType: asTreasureValueType(x.wealthValueType),
+  }));
+}
+
+/** Create or update a single treasure code. */
+export async function upsertTreasurecode(
+  tc: TreasureCode,
+  opts: { method?: 'POST' | 'PUT'; useResourceIdPath?: boolean } = {},
+) {
+  const { method = 'POST', useResourceIdPath = false } = opts;
+  const url = useResourceIdPath && tc?.id
+    ? `${BASE}/${encodeURIComponent(tc.id)}`
+    : `${BASE}/`;
+  return sendJson(url, method, tc);
+}
+
+/** DELETE /rmce/objects/treasurecode/{id} */
+export async function deleteTreasurecode(id: string) {
+  if (!id) throw new Error('deleteTreasurecode: id is required');
+  await fetchJson<void>(`${BASE}/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}

--- a/src/endpoints/skillcategory/SkillCategoryView.tsx
+++ b/src/endpoints/skillcategory/SkillCategoryView.tsx
@@ -71,7 +71,7 @@ const fromVM = (vm: FormState): SkillCategory => {
   };
 };
 
-export default function SkillcategoriesView() {
+export default function SkillCategoryView() {
   // data
   const [rows, setRows] = useState<SkillCategory[]>([]);
   const [spts, setSpts] = useState<SkillProgressionType[]>([]);
@@ -526,6 +526,12 @@ export default function SkillcategoriesView() {
           ariaLabel="Skill categories"
         />
       )}
-    </>
+
+      {/* Empty dataset */}
+      {!rows.length && !showForm && (
+        <div style={{ marginTop: 8, color: 'var(--muted)' }}>
+          No skill categories found.
+        </div>
+      )}    </>
   );
 }

--- a/src/endpoints/treasurecode/TreasureCodeView.tsx
+++ b/src/endpoints/treasurecode/TreasureCodeView.tsx
@@ -1,0 +1,332 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { DataTable, DataTableSearchInput, type ColumnDef } from '../../components/DataTable';
+import { LabeledInput, LabeledSelect } from '../../components/inputs';
+import { useToast } from '../../components/Toast';
+import { useConfirm } from '../../components/ConfirmDialog';
+
+import { fetchTreasurecodes, upsertTreasurecode, deleteTreasurecode } from '../../api/treasurecode';
+import type { TreasureCode } from '../../types/treasurecode';
+import { TREASUREVALUETYPES, type TreasureValueType } from '../../types/enum';
+
+import { isValidID, makeIDOnChange } from '../../utils/inputHelpers';
+
+const prefix = 'TREASURECODE_';
+
+/* ------------------------
+   Form VM (same shape, strings for selects are fine)
+------------------------- */
+type FormState = {
+  id: string;
+  itemsValueType: TreasureValueType | '';
+  wealthValueType: TreasureValueType | '';
+};
+
+const emptyVM = (): FormState => ({
+  id: prefix,
+  itemsValueType: '',
+  wealthValueType: '',
+});
+
+const toVM = (x: TreasureCode): FormState => ({
+  id: x.id,
+  itemsValueType: x.itemsValueType,
+  wealthValueType: x.wealthValueType,
+});
+
+const fromVM = (vm: FormState): TreasureCode => ({
+  id: vm.id.trim(),
+  itemsValueType: vm.itemsValueType as TreasureValueType,
+  wealthValueType: vm.wealthValueType as TreasureValueType,
+});
+
+
+export default function TreasureCodeView() {
+  const [rows, setRows] = useState<TreasureCode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [viewing, setViewing] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyVM());
+  const [errors, setErrors] = useState<{
+    id?: string | undefined;
+    itemsValueType?: string | undefined;
+    wealthValueType?: string | undefined;
+  }>({});
+
+  const toast = useToast();
+  const confirm = useConfirm();
+
+  // ---- Load ----
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const list = await fetchTreasurecodes();
+        if (!mounted) return;
+        setRows(list);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  // ---- Validation ----
+  const isTVT = (s: string) => (TREASUREVALUETYPES as readonly string[]).includes(s);
+
+  const computeErrors = (draft = form) => {
+    const e: typeof errors = {};
+    if (!draft.id.trim()) e.id = 'ID is required';
+    else if (!editingId && rows.some(r => r.id === draft.id.trim())) e.id = `ID "${draft.id.trim()}" already exists`;
+    else if (!isValidID(draft.id, prefix)) e.id = `ID must start with "${prefix}" and contain additional characters`;
+
+    if (!draft.itemsValueType) e.itemsValueType = 'Items value type is required';
+    else if (!isTVT(draft.itemsValueType)) e.itemsValueType = 'Pick a valid value';
+
+    if (!draft.wealthValueType) e.wealthValueType = 'Wealth value type is required';
+    else if (!isTVT(draft.wealthValueType)) e.wealthValueType = 'Pick a valid value';
+
+    return e;
+  };
+
+  const hasErrors = Boolean(errors.id || errors.itemsValueType || errors.wealthValueType);
+
+  useEffect(() => {
+    if (!showForm || viewing) return;
+    setErrors(computeErrors());
+  }, [form, showForm, viewing]);
+
+  // ---- Actions ----
+  const startNew = () => {
+    setViewing(false);
+    setEditingId(null);
+    setForm(emptyVM());
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startView = (row: TreasureCode) => {
+    setViewing(true);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startEdit = (row: TreasureCode) => {
+    setViewing(false);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startDuplicate = (row: TreasureCode) => {
+    setViewing(false);
+    setEditingId(null);
+    const vm = toVM(row);
+    vm.id = prefix;
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const cancelForm = () => {
+    setShowForm(false);
+    setViewing(false);
+    setEditingId(null);
+    setErrors({});
+  };
+
+  const saveForm = async () => {
+    const nextErrors = computeErrors(form);
+    setErrors(nextErrors);
+    if (hasErrors) return;
+
+    const payload = fromVM(form);
+    const isEditing = Boolean(editingId);
+    try {
+      const opts = isEditing
+        ? { method: 'PUT' as const, useResourceIdPath: true }
+        : { method: 'POST' as const, useResourceIdPath: false };
+      await upsertTreasurecode(payload, opts);
+
+      setRows(prev => {
+        if (isEditing) {
+          const idx = prev.findIndex(r => r.id === payload.id);
+          if (idx >= 0) {
+            const copy = [...prev];
+            copy[idx] = { ...copy[idx], ...payload };
+            return copy;
+          }
+          return [payload, ...prev];
+        }
+        return [payload, ...prev];
+      });
+
+      setShowForm(false);
+      setViewing(false);
+      setEditingId(null);
+      toast({
+        variant: 'success',
+        title: isEditing ? 'Updated' : 'Saved',
+        description: `Treasure code "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
+      });
+    } catch (err) {
+      toast({
+        variant: 'danger',
+        title: 'Save failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    }
+  };
+
+  // ---- Table ----
+  const columns: ColumnDef<TreasureCode>[] = useMemo(() => [
+    { id: 'id', header: 'ID', accessor: r => r.id, sortType: 'string', minWidth: 260 },
+    { id: 'itemsValueType', header: 'Items Value Type', accessor: r => r.itemsValueType, sortType: 'string', minWidth: 180 },
+    { id: 'wealthValueType', header: 'Wealth Value Type', accessor: r => r.wealthValueType, sortType: 'string', minWidth: 180 },
+    {
+      id: 'actions',
+      header: 'Actions',
+      sortable: false,
+      width: 340,
+      render: (row) => (
+        <>
+          <button onClick={() => startView(row)} style={{ marginRight: 6 }}>View</button>
+          <button onClick={() => startEdit(row)} style={{ marginRight: 6 }}>Edit</button>
+          <button onClick={() => startDuplicate(row)} style={{ marginRight: 6 }}>Duplicate</button>
+          <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
+        </>
+      ),
+    },
+  ], []);
+
+  const onDelete = async (row: TreasureCode) => {
+    const ok = await confirm({
+      title: 'Delete Treasure Code',
+      body: `Delete treasure code "${row.id}"? This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    const prev = rows;
+    setRows(prev.filter(r => r.id !== row.id));
+    try {
+      await deleteTreasurecode(row.id);
+      if (editingId === row.id || viewing) cancelForm();
+      toast({ variant: 'success', title: 'Deleted', description: `Treasure code "${row.id}" deleted.` });
+    } catch (err) {
+      setRows(prev);
+      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err) });
+    }
+  };
+
+  const globalFilter = (r: TreasureCode, q: string) => {
+    const s = q.toLowerCase();
+    return [r.id, r.itemsValueType, r.wealthValueType]
+      .some(v => String(v ?? '').toLowerCase().includes(s));
+  };
+
+  if (loading) return <div>Loading…</div>;
+  if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
+
+  return (
+    <>
+      <h2>Treasure Codes</h2>
+
+      {/* Toolbar hidden while form is visible */}
+      {!showForm && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '12px 0' }}>
+          <button onClick={startNew}>New Treasure Code</button>
+          <DataTableSearchInput
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search treasure codes…"
+            aria-label="Search treasure codes"
+          />
+        </div>
+      )}
+
+      {/* Form panel */}
+      {showForm && (
+        <div
+          className={`form-panel ${viewing ? 'form-panel--view' : ''}`}
+          style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}
+        >
+          <h3 style={{ marginTop: 0 }}>
+            {viewing ? 'View Treasure Code' : (editingId ? 'Edit Treasure Code' : 'New Treasure Code')}
+          </h3>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <LabeledInput label="ID" value={form.id} onChange={makeIDOnChange<typeof form>('id', setForm, prefix)} disabled={!!editingId || viewing} error={errors.id} />
+
+            <LabeledSelect
+              label="Items Value Type"
+              value={form.itemsValueType}
+              onChange={(v) => setForm(s => ({ ...s, itemsValueType: v as TreasureValueType }))}
+              options={TREASUREVALUETYPES}
+              disabled={viewing}
+              error={viewing ? undefined : errors.itemsValueType}
+            />
+
+            <LabeledSelect
+              label="Wealth Value Type"
+              value={form.wealthValueType}
+              onChange={(v) => setForm(s => ({ ...s, wealthValueType: v as TreasureValueType }))}
+              options={TREASUREVALUETYPES}
+              disabled={viewing}
+              error={viewing ? undefined : errors.wealthValueType}
+            />
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+            {!viewing && <button onClick={saveForm} disabled={hasErrors}>Save</button>}
+            <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
+          </div>
+        </div>
+      )}
+
+      {/* Table hidden while form is visible */}
+      {!showForm && (
+        <DataTable<TreasureCode>
+          rows={rows}
+          columns={columns}
+          rowId={(r) => r.id}
+          initialSort={{ colId: 'id', dir: 'asc' }}
+          searchQuery={query}
+          globalFilter={globalFilter}
+          mode="client"
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          pageSizeOptions={[5, 10, 20, 50, 100]}
+          tableMinWidth={800}
+          zebra
+          hover
+          resizable
+          persistKey="dt.treasurecode.v1"
+          ariaLabel="Treasure codes"
+        />
+      )}
+
+      {/* Empty dataset */}
+      {!rows.length && !showForm && (
+        <div style={{ marginTop: 8, color: 'var(--muted)' }}>
+          No treasure codes found.
+        </div>
+      )}    </>
+  );
+}

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -14,6 +14,7 @@ const SkillCategoryView = lazy(() => import('../endpoints/skillcategory/SkillCat
 const SkillGroupView = lazy(() => import('../endpoints/skillgroup/SkillGroupView'));
 const SkillProgressionTypeView = lazy(() => import('../endpoints/skillprogressiontype/SkillProgressionTypeView'));
 const SpellListView = lazy(() => import('../endpoints/spelllist/SpellListView'));
+const TreasureCodeView = lazy(() => import('../endpoints/treasurecode/TreasureCodeView'));
 
 
 export interface ResourceDef {
@@ -22,7 +23,6 @@ export interface ResourceDef {
   path: `/${string}`;
   Component: LazyExoticComponent<ComponentType>;
 }
-
 /** Known resources with their routes/components */
 
 const known: Record<string, ResourceDef> = {
@@ -40,6 +40,7 @@ const known: Record<string, ResourceDef> = {
   skillgroup: { prefix: 'skillgroup', label: 'Skill Groups', path: '/skillgroups', Component: SkillGroupView },
   skillprogressiontype: { prefix: 'skillprogressiontype', label: 'Skill Progression Types', path: '/skillprogressiontypes', Component: SkillProgressionTypeView },
   spelllist: { prefix: 'spelllist', label: 'Spell Lists', path: '/spelllists', Component: SpellListView },
+  treasurecode: { prefix: 'treasurecode', label: 'Treasure Codes', path: '/treasurecodes', Component:TreasureCodeView },
 }
 
 
@@ -71,4 +72,5 @@ export const FALLBACK_RESOURCES: ResourceDef[] = [
   known.skillgroup,
   known.skillprogressiontype,
   known.spelllist,
+  known.treasurecode,
 ].filter((r): r is ResourceDef => Boolean(r));

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -41,3 +41,7 @@ export const SPELL_TYPES: ReadonlyArray<SpellType> = ['Base', 'Closed', 'Open', 
 export type Stat = 'Agility' | 'Constitution' | 'Empathy' | 'Intuition' | 'Memory' | 'Presence' | 'Quickness' | 'Reasoning' | 'Self Discipline' | 'Strength';
 export const STATS: ReadonlyArray<Stat> = ['Agility', 'Constitution', 'Empathy', 'Intuition', 'Memory', 'Presence', 'Quickness', 'Reasoning', 'Self Discipline', 'Strength'] as const;
 export const DEVELOPMENT_STATS: ReadonlyArray<Stat> = ['Agility', 'Constitution', 'Empathy', 'Intuition', 'Memory'] as const;
+
+/** Enum for treasure value types */
+export type TreasureValueType = 'Very Poor' | 'Poor' | 'Normal' | 'Rich' | 'Very Rich' | 'Special';
+export const TREASUREVALUETYPES: ReadonlyArray<TreasureValueType> = ['Very Poor', 'Poor', 'Normal', 'Rich', 'Very Rich', 'Special'] as const;

--- a/src/types/treasurecode.ts
+++ b/src/types/treasurecode.ts
@@ -1,0 +1,14 @@
+// ------------------------
+// Treasure Codes
+// ------------------------
+import type { TreasureValueType } from './enum'; // adjust the relative path if needed
+
+export interface TreasureCode {
+  id: string;
+  itemsValueType: TreasureValueType;
+  wealthValueType: TreasureValueType;
+}
+
+export interface TreasureCodesPayload {
+  treasurecodes: TreasureCode[];
+}


### PR DESCRIPTION
This pull request introduces a new "Treasure Codes" resource to the application, including full frontend support for CRUD operations, data validation, and integration into the resource registry. The changes include new API functions, type definitions, UI components, and the necessary updates to enums and resource registration.

**New Treasure Codes resource:**

- Added `TreasureCodeView` React component for listing, searching, creating, editing, viewing, duplicating, and deleting treasure codes, with form validation and user feedback. (`src/endpoints/treasurecode/TreasureCodeView.tsx`)
- Added API functions for fetching, upserting, and deleting treasure codes, with type-safe value handling and fallback for unknown enum values. (`src/api/treasurecode.ts`)
- Defined new types for treasure codes and their network payloads. (`src/types/treasurecode.ts`)
- Introduced a new enum and type for `TreasureValueType` to standardize value types for treasure codes. (`src/types/enum.ts`)

**Resource registry integration:**

- Registered the "Treasure Codes" resource in the resource registry so it appears in the UI alongside other resources. (`src/resources/registry.ts`) [[1]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R17) [[2]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R43) [[3]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R75)

**Minor improvements:**

- Improved empty state handling for the skill categories view by displaying a message when no data is present, and fixed the default export name for consistency. (`src/endpoints/skillcategory/SkillCategoryView.tsx`) [[1]](diffhunk://#diff-8a2618cc9db38550e5753eb91c737a77702a4aae4698826eec202f326f6e1faeL529-R535) [[2]](diffhunk://#diff-8a2618cc9db38550e5753eb91c737a77702a4aae4698826eec202f326f6e1faeL74-R74)