### PR TITLE
Refactor attack table editor to own file for reuse

### DIFF
--- a/src/components/inputs/AttackTableEditor.tsx
+++ b/src/components/inputs/AttackTableEditor.tsx
@@ -1,0 +1,321 @@
+import * as React from 'react';
+import { LabeledInput } from './LabeledInput';
+
+export type AttackTableRowVM = {
+  min: string;
+  max: string;
+  /** Exactly 20 cells (at1..at20). Keep strings to allow tokens like "6|Krush:A". */
+  cells: string[];
+};
+
+type Props = {
+  sectionKey: 'modified' | 'unmodified' | string;
+  title: string;
+  rows: AttackTableRowVM[];
+  onChangeRows: (next: AttackTableRowVM[]) => void;
+  viewing?: boolean | undefined;
+  error?: string | undefined;
+
+  /** Optional: number of AT columns; defaults to 20 */
+  atColumns?: number | undefined;
+
+  /** Width for min/max inputs; defaults to 72px */
+  minMaxWidth?: number | string | undefined;
+
+  /** Width for each at* input cell; undefined = use default input width */
+  atCellWidth?: number | string | undefined;
+
+  /** Show “Add row” even when viewing (rare). Defaults false. */
+  allowAddInView?: boolean | undefined;
+};
+
+export function AttackTableEditor({
+  sectionKey,
+  title,
+  rows,
+  onChangeRows,
+  viewing,
+  error,
+  atColumns = 20,
+  minMaxWidth = 72,
+  atCellWidth,
+  allowAddInView = false,
+}: Props) {
+  const totalCols = 2 + atColumns + 1; // min, max, at*, actions
+
+  const gridStyle: React.CSSProperties = React.useMemo(() => {
+    const atWidths = Array.from({ length: atColumns }, () => '70px').join(' ');
+    return {
+      display: 'grid',
+      gridTemplateColumns: `90px 90px ${atWidths} 100px`,
+      gap: 6,
+      alignItems: 'center',
+    };
+  }, [atColumns]);
+
+  const focusCell = (r: number, c: number) => {
+    const id = `${sectionKey}-${r}-${c}`;
+    const el = document.getElementById(id) as HTMLInputElement | null;
+    el?.focus();
+    el?.select?.();
+  };
+
+  const handleNav = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (viewing) return;
+    const r = Number(e.currentTarget.dataset.row);
+    const c = Number(e.currentTarget.dataset.col);
+    if (Number.isNaN(r) || Number.isNaN(c)) return;
+
+    const atStart = e.currentTarget.selectionStart === 0;
+    const atEnd = e.currentTarget.selectionStart === e.currentTarget.value.length;
+
+    switch (e.key) {
+      case 'ArrowLeft':
+        if (!atStart) return;
+        e.preventDefault();
+        if (c > 0) focusCell(r, c - 1);
+        break;
+      case 'ArrowRight':
+        if (!atEnd) return;
+        e.preventDefault();
+        if (c < totalCols - 1) focusCell(r, c + 1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        if (r > 0) focusCell(r - 1, c);
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        if (r < rows.length - 1) focusCell(r + 1, c);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (e.shiftKey) {
+          if (r > 0) focusCell(r - 1, c);
+        } else {
+          if (r < rows.length - 1) focusCell(r + 1, c);
+        }
+        break;
+    }
+  };
+
+  const parsePasted = (text: string): string[] => {
+    if (!text) return [];
+    if (text.includes('\t')) return text.split('\t').map((s) => s.trim());
+    if (text.includes(',')) return text.split(',').map((s) => s.trim());
+    return text.trim().split(/\s+/);
+  };
+
+  // full-row update helpers to avoid type widening
+  const updateRowField = (row: AttackTableRowVM, key: 'min' | 'max', val: string): AttackTableRowVM => {
+    return { min: key === 'min' ? val : row.min, max: key === 'max' ? val : row.max, cells: row.cells.slice() };
+  };
+  const updateRowCell = (row: AttackTableRowVM, index: number, val: string): AttackTableRowVM => {
+    const cells = row.cells.slice();
+    if (index >= 0 && index < atColumns) {
+      cells[index] = val;
+    }
+    return { min: row.min, max: row.max, cells };
+  };
+
+  const onPasteCells = (
+    rowIdx: number,
+    startCol: number,
+    e: React.ClipboardEvent<HTMLInputElement>
+  ) => {
+    if (viewing) return;
+    e.preventDefault();
+
+    const values = parsePasted(e.clipboardData.getData('text'));
+    if (!values.length) return;
+
+    // 1) Bounds check + narrow
+    if (rowIdx < 0 || rowIdx >= rows.length) return;
+
+    const isInt = (s: string | undefined) => !!s && /^\d+$/.test(s);
+
+    // 2) Clone array & take a non-null row reference
+    const next = rows.slice();
+    const row0 = next[rowIdx];
+    if (!row0) return;
+
+    // Work on a non-optional RowVM copy
+    let curr: AttackTableRowVM = { min: row0.min, max: row0.max, cells: row0.cells.slice() };
+
+    // Fill cells & return full row
+    const fillCellsFrom = (row: AttackTableRowVM, src: string[], startAt: number): AttackTableRowVM => {
+      const cells = row.cells.slice();
+      const limit = Math.min(atColumns, src.length);
+      for (let i = 0; i < limit; i++) {
+        const idx = startAt + i;
+        if (idx >= atColumns) break;
+        const v = src[i] ?? '-';
+        cells[idx] = v === '' ? '-' : v;
+      }
+      return { min: row.min, max: row.max, cells };
+    };
+
+    if (startCol === 0) {
+      const [minMaybe, maxMaybe, ...rest] = values;
+      const min = isInt(minMaybe) ? minMaybe! : curr.min;
+      const max = isInt(maxMaybe) ? maxMaybe! : curr.max;
+      const base = isInt(minMaybe) && isInt(maxMaybe) ? rest : values;
+      curr = { min, max, cells: curr.cells.slice() };
+      curr = fillCellsFrom(curr, base, 0);
+    } else if (startCol === 1) {
+      const [maxMaybe, ...rest] = values;
+      const max = isInt(maxMaybe) ? maxMaybe! : curr.max;
+      const base = isInt(maxMaybe) && rest.length ? rest : values;
+      curr = { min: curr.min, max, cells: curr.cells.slice() };
+      curr = fillCellsFrom(curr, base, 0);
+    } else {
+      const cellIdx = Math.max(0, startCol - 2);
+      curr = fillCellsFrom(curr, values, cellIdx);
+    }
+
+    next[rowIdx] = curr;
+    onChangeRows(next);
+  };
+
+  const header = (
+    <div style={gridStyle}>
+      <div style={{ fontWeight: 600 }}>Min</div>
+      <div style={{ fontWeight: 600 }}>Max</div>
+      {Array.from({ length: atColumns }, (_, i) => (
+        <div key={`h-${i}`} style={{ fontWeight: 600 }}>{`AT ${i + 1}`}</div>
+      ))}
+      <div style={{ fontWeight: 600 }}>Actions</div>
+    </div>
+  );
+
+  const canAdd = !viewing || allowAddInView;
+
+  return (
+    <section style={{ marginTop: 8 }}>
+      <h4 style={{ margin: '8px 0' }}>{title}</h4>
+
+      {canAdd && (
+        <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+          <button
+            type="button"
+            onClick={() => onChangeRows([...rows, { min: '', max: '', cells: Array(atColumns).fill('-') }])}
+          >
+            + Add row
+          </button>
+          {error && <span style={{ color: '#b00020' }}>{error}</span>}
+        </div>
+      )}
+      {!canAdd && error && <div style={{ color: '#b00020' }}>{error}</div>}
+
+      {header}
+
+      <div role="grid" aria-label={`${title} grid`} style={{ display: 'grid', gap: 6 }}>
+        {rows.map((r, rowIdx) => (
+          <div key={`${sectionKey}-row-${rowIdx}`} style={gridStyle}>
+            {/* Min */}
+            <LabeledInput
+              label="Min"
+              hideLabel
+              ariaLabel="Min"
+              value={r.min}
+              onChange={(val) => {
+                if (viewing) return;
+                const digits = val.replace(/[^\d]/g, '');
+                const next = rows.slice();
+                if (rowIdx < 0 || rowIdx >= next.length) return;
+                const row = next[rowIdx]; if (!row) return;
+                next[rowIdx] = updateRowField(row, 'min', digits);
+                onChangeRows(next);
+              }}
+              disabled={viewing}
+              width={minMaxWidth}
+              inputProps={{ inputMode: 'numeric', pattern: '^\\d+$' }}
+            />
+
+            {/* Max */}
+            <LabeledInput
+              label="Max"
+              hideLabel
+              ariaLabel="Max"
+              value={r.max}
+              onChange={(val) => {
+                if (viewing) return;
+                const digits = val.replace(/[^\d]/g, '');
+                const next = rows.slice();
+                if (rowIdx < 0 || rowIdx >= next.length) return;
+                const row = next[rowIdx]; if (!row) return;
+                next[rowIdx] = updateRowField(row, 'max', digits);
+                onChangeRows(next);
+              }}
+              disabled={viewing}
+              width={minMaxWidth}
+              inputProps={{ inputMode: 'numeric', pattern: '^\\d+$' }}
+            />
+
+            {/* AT1..ATN */}
+            {r.cells.map((cell, i) => (
+              <input
+                key={`${sectionKey}-${rowIdx}-c-${i}`}
+                id={`${sectionKey}-${rowIdx}-${i + 2}`}
+                data-row={rowIdx}
+                data-col={i + 2}
+                value={cell}
+                onChange={(e) => {
+                  if (viewing) return;
+                  const val = e.target.value;
+                  const next = rows.slice();
+                  if (rowIdx < 0 || rowIdx >= next.length) return;
+                  const row = next[rowIdx]; if (!row) return;
+                  next[rowIdx] = updateRowCell(row, i, val === '' ? '' : val);
+                  onChangeRows(next);
+                }}
+                onKeyDown={handleNav}
+                onPaste={(e) => onPasteCells(rowIdx, i + 2, e)}
+                disabled={viewing}
+                style={{
+                  padding: 6,
+                  ...(atCellWidth
+                    ? { width: typeof atCellWidth === 'number' ? `${atCellWidth}px` : atCellWidth }
+                    : {}),
+                }}
+                aria-label={`Row ${rowIdx + 1} AT${i + 1}`}
+              />
+            ))}
+
+            {/* Actions */}
+            <div style={{ display: 'flex', gap: 6 }}>
+              {!viewing && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const clone: AttackTableRowVM = { min: r.min, max: r.max, cells: r.cells.slice() };
+                      const next = rows.slice();
+                      next.splice(rowIdx + 1, 0, clone);
+                      onChangeRows(next);
+                    }}
+                    title="Duplicate row"
+                  >
+                    Duplicate
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const next = rows.slice();
+                      next.splice(rowIdx, 1);
+                      onChangeRows(next);
+                    }}
+                    title="Remove row"
+                    style={{ color: '#b00020' }}
+                  >
+                    Remove
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/inputs/index.ts
+++ b/src/components/inputs/index.ts
@@ -2,3 +2,4 @@ export * from './CheckboxGroup';
 export * from './CheckboxInput';
 export * from './LabeledInput';
 export * from './LabeledSelect';
+export * from './AttackTableEditor';

--- a/src/endpoints/attacktable/AttackTableView.tsx
+++ b/src/endpoints/attacktable/AttackTableView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { DataTable, DataTableSearchInput, type ColumnDef } from '../../components/DataTable';
-import { LabeledInput, LabeledSelect } from '../../components/inputs';
+import { LabeledInput, AttackTableEditor, AttackTableRowVM } from '../../components/inputs';
 import { useToast } from '../../components/Toast';
 import { useConfirm } from '../../components/ConfirmDialog';
 
@@ -14,18 +14,12 @@ const prefix = 'ATTACKTABLE_';
 /* -------------------------------------------------------
    Form VM (string inputs for numbers; rows edited via cells CSV)
 ------------------------------------------------------- */
-type RowVM = {
-  min: string;
-  max: string;
-  cells: string[]; // exactly 20
-};
-
 type FormState = {
   id: string;
   name: string;
   maxRow: string;
-  modified: RowVM[];
-  unmodified: RowVM[];
+  modified: AttackTableRowVM[];
+  unmodified: AttackTableRowVM[];
 };
 
 // Initial form state
@@ -45,13 +39,13 @@ function ensure20(a: string[]): string[] {
 }
 
 // Convert API row -> VM row
-function rowToVM(r: AttackTableRow): RowVM {
+function rowToVM(r: AttackTableRow): AttackTableRowVM {
   const cells = Array.from({ length: 20 }, (_, i) => String((r as any)[`at${i + 1}`] ?? '-'));
   return { min: String(r.min), max: String(r.max), cells };
 }
 
 // Convert VM row -> API row
-function vmToRow(vm: RowVM): AttackTableRow {
+function vmToRow(vm: AttackTableRowVM): AttackTableRow {
   const min = Number(vm.min);
   const max = Number(vm.max);
   const fixed = ensure20(vm.cells.map(s => s.trim()));
@@ -83,10 +77,10 @@ function fromVM(vm: FormState): AttackTable {
 }
 
 // Helpers to update a row WITHOUT type widening
-function updateRowField(row: RowVM, key: 'min' | 'max', val: string): RowVM {
+function updateRowField(row: AttackTableRowVM, key: 'min' | 'max', val: string): AttackTableRowVM {
   return { min: key === 'min' ? val : row.min, max: key === 'max' ? val : row.max, cells: row.cells.slice() };
 }
-function updateRowCell(row: RowVM, index: number, val: string): RowVM {
+function updateRowCell(row: AttackTableRowVM, index: number, val: string): AttackTableRowVM {
   const cells = row.cells.slice();
   cells[index] = val;
   return { min: row.min, max: row.max, cells };
@@ -135,7 +129,7 @@ export default function AttacktablesView() {
   }, []);
 
   // ---- Validation ----
-  function validateRowVM(label: 'modified' | 'unmodified', r: RowVM | undefined, idx: number): string | undefined {
+  function validateRowVM(label: 'modified' | 'unmodified', r: AttackTableRowVM | undefined, idx: number): string | undefined {
     if (!r) return `${label}[${idx + 1}]: row is undefined`;
     if (!isValidUnsignedInt(r.min) || !isValidUnsignedInt(r.max)) {
       return `${label}[${idx + 1}]: min/max must be non-negative integers`;
@@ -401,25 +395,26 @@ export default function AttacktablesView() {
             />
           </div>
 
-
           {/* Modified Rows */}
-          <RichRowsEditor
+          <AttackTableEditor
             sectionKey="modified"
             title="Modified Rows"
             rows={form.modified}
-            onChangeRows={(next) => setForm(s => ({ ...s, modified: next }))}
+            onChangeRows={(next) => setForm((s) => ({ ...s, modified: next }))}
             viewing={viewing}
             error={errors.modified}
+            minMaxWidth={72}
           />
 
           {/* Unmodified Rows */}
-          <RichRowsEditor
+          <AttackTableEditor
             sectionKey="unmodified"
             title="Unmodified Rows (optional)"
             rows={form.unmodified}
-            onChangeRows={(next) => setForm(s => ({ ...s, unmodified: next }))}
+            onChangeRows={(next) => setForm((s) => ({ ...s, unmodified: next }))}
             viewing={viewing}
             error={errors.unmodified}
+            minMaxWidth={72}
           />
 
           {/* Buttons */}
@@ -454,280 +449,5 @@ export default function AttacktablesView() {
         />
       )}
     </>
-  );
-}
-
-/* ============================================================================================
-   RichRowsEditor: compact grid for RowVM[]  (replaces the three LabeledInput fields)
-   ============================================================================================ */
-function RichRowsEditor({
-  sectionKey,
-  title,
-  rows,
-  onChangeRows,
-  viewing,
-  error,
-}: {
-  sectionKey: 'modified' | 'unmodified';
-  title: string;
-  rows: RowVM[];
-  onChangeRows: (next: RowVM[]) => void;
-  viewing?: boolean | undefined;
-  error?: string | undefined;
-}) {
-  const gridStyle: React.CSSProperties = {
-    display: 'grid',
-    gridTemplateColumns: '90px 90px repeat(20, 70px) 100px',
-    gap: 6,
-    alignItems: 'center',
-  };
-  const totalCols = 22; // 0=min, 1=max, 2..21 = 20 cells
-
-  const focusCell = (r: number, c: number) => {
-    const id = `${sectionKey}-${r}-${c}`;
-    const el = document.getElementById(id) as HTMLInputElement | null;
-    el?.focus();
-    el?.select?.();
-  };
-
-  const handleNav = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (viewing) return;
-    const r = Number(e.currentTarget.dataset.row);
-    const c = Number(e.currentTarget.dataset.col);
-    if (Number.isNaN(r) || Number.isNaN(c)) return;
-
-    const atStart = e.currentTarget.selectionStart === 0;
-    const atEnd = e.currentTarget.selectionStart === e.currentTarget.value.length;
-
-    switch (e.key) {
-      case 'ArrowLeft':
-        if (!atStart) return;
-        e.preventDefault();
-        if (c > 0) focusCell(r, c - 1);
-        break;
-      case 'ArrowRight':
-        if (!atEnd) return;
-        e.preventDefault();
-        if (c < totalCols - 1) focusCell(r, c + 1);
-        break;
-      case 'ArrowUp':
-        e.preventDefault();
-        if (r > 0) focusCell(r - 1, c);
-        break;
-      case 'ArrowDown':
-        e.preventDefault();
-        if (r < rows.length - 1) focusCell(r + 1, c);
-        break;
-      case 'Enter':
-        e.preventDefault();
-        if (e.shiftKey) {
-          if (r > 0) focusCell(r - 1, c);
-        } else {
-          if (r < rows.length - 1) focusCell(r + 1, c);
-        }
-        break;
-    }
-  };
-
-  // Accept CSV/TSV/whitespace — always return string[]
-  const parsePasted = (text: string): string[] => {
-    if (!text) return [];
-    if (text.includes('\t')) return text.split('\t').map((s) => s.trim());
-    if (text.includes(',')) return text.split(',').map((s) => s.trim());
-    return text.trim().split(/\s+/);
-  };
-
-  const onPasteCells = (
-    rowIdx: number,
-    startCol: number,
-    e: React.ClipboardEvent<HTMLInputElement>
-  ) => {
-    if (viewing) return;
-    e.preventDefault();
-
-    const values = parsePasted(e.clipboardData.getData('text'));
-    if (!values.length) return;
-
-    // 1) Bounds check row index
-    if (rowIdx < 0 || rowIdx >= rows.length) return;
-
-    const isInt = (s: string | undefined) => !!s && /^\d+$/.test(s);
-
-    // 2) Clone array and narrow the row reference
-    const next = rows.slice();
-    const row0 = next[rowIdx];
-    if (!row0) return; // <-- TS now knows row0 is RowVM below
-
-    // Work on a non-optional RowVM copy
-    let curr: RowVM = { min: row0.min, max: row0.max, cells: row0.cells.slice() };
-
-    // Helper: return a full RowVM with cells applied
-    const fillCellsFrom = (row: RowVM, src: string[], startAt: number): RowVM => {
-      const cells = row.cells.slice();
-      const limit = Math.min(20, src.length);
-      for (let i = 0; i < limit; i++) {
-        const idx = startAt + i;
-        if (idx >= 20) break;
-        const v = src[i] ?? '-';
-        cells[idx] = v === '' ? '-' : v;  // ensure string
-      }
-      return { min: row.min, max: row.max, cells };
-    };
-
-    // 3) Apply paste
-    if (startCol === 0) {
-      const [minMaybe, maxMaybe, ...rest] = values;
-      const min = isInt(minMaybe) ? minMaybe! : curr.min;
-      const max = isInt(maxMaybe) ? maxMaybe! : curr.max;
-      const base = isInt(minMaybe) && isInt(maxMaybe) ? rest : values;
-      curr = { min, max, cells: curr.cells.slice() };
-      curr = fillCellsFrom(curr, base, 0);
-    } else if (startCol === 1) {
-      const [maxMaybe, ...rest] = values;
-      const max = isInt(maxMaybe) ? maxMaybe! : curr.max;
-      const base = isInt(maxMaybe) && rest.length ? rest : values;
-      curr = { min: curr.min, max, cells: curr.cells.slice() };
-      curr = fillCellsFrom(curr, base, 0);
-    } else {
-      const cellIdx = Math.max(0, startCol - 2);
-      curr = fillCellsFrom(curr, values, cellIdx);
-    }
-
-    // 4) Commit back a full RowVM (no partials, no widening)
-    next[rowIdx] = curr;
-    onChangeRows(next);
-  };
-
-  const header = (
-    <div style={gridStyle}>
-      <div style={{ fontWeight: 600 }}>min</div>
-      <div style={{ fontWeight: 600 }}>max</div>
-      {Array.from({ length: 20 }, (_, i) => (
-        <div key={`h-${i}`} style={{ fontWeight: 600 }}>{`at${i + 1}`}</div>
-      ))}
-      <div style={{ fontWeight: 600 }}>actions</div>
-    </div>
-  );
-
-  return (
-    <section style={{ marginTop: 8 }}>
-      <h4 style={{ margin: '8px 0' }}>{title}</h4>
-
-      {!viewing && (
-        <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
-          <button
-            type="button"
-            onClick={() =>
-              onChangeRows([...rows, { min: '', max: '', cells: Array(20).fill('-') }])
-            }
-          >
-            + Add row
-          </button>
-          {error && <span style={{ color: '#b00020' }}>{error}</span>}
-        </div>
-      )}
-      {viewing && error && <div style={{ color: '#b00020' }}>{error}</div>}
-
-      {header}
-
-      <div role="grid" aria-label={`${title} grid`} style={{ display: 'grid', gap: 6 }}>
-        {rows.map((r, rowIdx) => (
-          <div key={`${sectionKey}-row-${rowIdx}`} style={gridStyle}>
-            {/* min */}
-            <LabeledInput
-              label="min"
-              hideLabel
-              value={r.min}
-              onChange={(val) => {
-                if (viewing) return;
-                const digits = val.replace(/[^\d]/g, '');
-                if (rowIdx < 0 || rowIdx >= rows.length) return;
-                const next = rows.slice();
-                next[rowIdx] = updateRowField(r, 'min', digits);
-                onChangeRows(next);
-              }}
-              disabled={viewing}
-              width={64}
-              inputProps={{ inputMode: 'numeric', pattern: '^\\d+$' }}
-            />
-
-            {/* max */}
-            <LabeledInput
-              label="max"
-              hideLabel
-              value={r.max}
-              onChange={(val) => {
-                if (viewing) return;
-                const digits = val.replace(/[^\d]/g, '');
-                if (rowIdx < 0 || rowIdx >= rows.length) return;
-                const next = rows.slice();
-                next[rowIdx] = updateRowField(r, 'max', digits);
-                onChangeRows(next);
-              }}
-              disabled={viewing}
-              width={64}
-              inputProps={{ inputMode: 'numeric', pattern: '^\\d+$' }}
-            />
-
-            {/* at1..at20 */}
-            {r.cells.map((cell, i) => (
-              <input
-                key={`${sectionKey}-${rowIdx}-c-${i}`}
-                id={`${sectionKey}-${rowIdx}-${i + 2}`}
-                data-row={rowIdx}
-                data-col={i + 2}
-                value={cell}
-                onChange={(e) => {
-                  if (viewing) return;
-                  const val = e.target.value;
-                  const next = rows.slice();
-                  if (rowIdx < 0 || rowIdx >= next.length) return;
-                  const row = next[rowIdx]; if (!row) return;
-                  next[rowIdx] = updateRowCell(row, i, val === '' ? '' : val);  // a full RowVM
-                  onChangeRows(next);
-                }}
-                onKeyDown={handleNav}
-                onPaste={(e) => onPasteCells(rowIdx, i + 2, e)}
-                disabled={viewing}
-                style={{ padding: 6 }}
-                aria-label={`Row ${rowIdx + 1} at${i + 1}`}
-              />
-            ))}
-
-            {/* actions */}
-            <div style={{ display: 'flex', gap: 6 }}>
-              {!viewing && (
-                <>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      const clone: RowVM = { min: r.min, max: r.max, cells: r.cells.slice() };
-                      const next = rows.slice();
-                      next.splice(rowIdx + 1, 0, clone);
-                      onChangeRows(next);
-                    }}
-                    title="Duplicate row"
-                  >
-                    Duplicate
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      const next = rows.slice();
-                      next.splice(rowIdx, 1);
-                      onChangeRows(next);
-                    }}
-                    title="Remove row"
-                    style={{ color: '#b00020' }}
-                  >
-                    Remove
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
   );
 }


### PR DESCRIPTION
This pull request refactors the attack table row editing functionality to use a new, reusable `AttackTableEditor` component. The change streamlines the UI code, improves maintainability, and ensures consistent behavior for editing attack table rows across the app. The previous inline `RichRowsEditor` implementation has been removed and replaced with the new component, and all relevant types and helpers have been updated to use the shared `AttackTableRowVM` type.

Component refactoring and consolidation:

* Introduced the new `AttackTableEditor` component in `src/components/inputs/AttackTableEditor.tsx`, encapsulating all logic for editing attack table rows, including keyboard navigation, paste handling, and row actions.
* Removed the old inline `RichRowsEditor` implementation from `src/endpoints/attacktable/AttackTableView.tsx`, replacing its usage with the new `AttackTableEditor` component for both modified and unmodified rows. [[1]](diffhunk://#diff-cbaa16536a402befac75bcf5f0934732278925a957a58f69b67cbb6ba1a72459L404-R417) [[2]](diffhunk://#diff-cbaa16536a402befac75bcf5f0934732278925a957a58f69b67cbb6ba1a72459L459-L733)

Type and helper updates:

* Updated all row types in `AttackTableView.tsx` to use the shared `AttackTableRowVM` type exported from the new component, ensuring type consistency across the codebase.
* Refactored row conversion and update helpers (`rowToVM`, `vmToRow`, `updateRowField`, `updateRowCell`) to use `AttackTableRowVM` instead of the previous local type. [[1]](diffhunk://#diff-cbaa16536a402befac75bcf5f0934732278925a957a58f69b67cbb6ba1a72459L48-R48) [[2]](diffhunk://#diff-cbaa16536a402befac75bcf5f0934732278925a957a58f69b67cbb6ba1a72459L86-R83)
* Updated validation functions to use the new row type.

Exports and imports:

* Exported `AttackTableEditor` and `AttackTableRowVM` from the inputs index for easy reuse throughout the app. [[1]](diffhunk://#diff-826546160d96c814d8f68b64d417b947f012e88ced18007503a3b50a54cd5da9R5) [[2]](diffhunk://#diff-cbaa16536a402befac75bcf5f0934732278925a957a58f69b67cbb6ba1a72459L3-R3)