### PR TITLE
Use ArmourType enum for attack table row headings

### DIFF
--- a/src/components/inputs/AttackTableEditor.tsx
+++ b/src/components/inputs/AttackTableEditor.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { LabeledInput } from './LabeledInput';
+import { ARMOUR_TYPES } from '../../types/enum';
 
 export type AttackTableRowVM = {
   min: string;
@@ -36,7 +37,7 @@ export function AttackTableEditor({
   onChangeRows,
   viewing,
   error,
-  atColumns = 20,
+  atColumns = ARMOUR_TYPES.length,
   minMaxWidth = 72,
   atCellWidth,
   allowAddInView = false,
@@ -181,8 +182,8 @@ export function AttackTableEditor({
     <div style={gridStyle}>
       <div style={{ fontWeight: 600 }}>Min</div>
       <div style={{ fontWeight: 600 }}>Max</div>
-      {Array.from({ length: atColumns }, (_, i) => (
-        <div key={`h-${i}`} style={{ fontWeight: 600 }}>{`AT ${i + 1}`}</div>
+      {ARMOUR_TYPES.map((at, i) => (
+        <div key={`h-${i}`} style={{ fontWeight: 600 }}>{at}</div>
       ))}
       <div style={{ fontWeight: 600 }}>Actions</div>
     </div>

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -45,3 +45,7 @@ export const DEVELOPMENT_STATS: ReadonlyArray<Stat> = ['Agility', 'Constitution'
 /** Enum for treasure value types */
 export type TreasureValueType = 'Very Poor' | 'Poor' | 'Normal' | 'Rich' | 'Very Rich' | 'Special';
 export const TREASUREVALUETYPES: ReadonlyArray<TreasureValueType> = ['Very Poor', 'Poor', 'Normal', 'Rich', 'Very Rich', 'Special'] as const;
+
+//** Enum for armour types  */
+export type ArmourType = 'AT 1' | 'AT 2' | 'AT 3' | 'AT 4' | 'AT 5' | 'AT 6' | 'AT 7' | 'AT 8' | 'AT 9' | 'AT 10' | 'AT 11' | 'AT 12' | 'AT 13' | 'AT 14' | 'AT 15' | 'AT 16' | 'AT 17' | 'AT 18' | 'AT 19' | 'AT 20';
+export const ARMOUR_TYPES: ReadonlyArray<ArmourType> = ['AT 1', 'AT 2', 'AT 3', 'AT 4', 'AT 5', 'AT 6', 'AT 7', 'AT 8', 'AT 9', 'AT 10', 'AT 11', 'AT 12', 'AT 13', 'AT 14', 'AT 15', 'AT 16', 'AT 17', 'AT 18', 'AT 19', 'AT 20'] as const;


### PR DESCRIPTION
This pull request updates the handling of armour types in the attack table editor to use a centralized enum definition. The changes improve consistency and maintainability by referencing the `ARMOUR_TYPES` array instead of hardcoding values.

Improvements to armour type handling:

* Introduced the `ArmourType` type and the `ARMOUR_TYPES` constant in `src/types/enum.ts`, providing a single source of truth for armour types.
* Updated `AttackTableEditor` to import and use `ARMOUR_TYPES` for determining column count and header labels, replacing hardcoded values and labels. [[1]](diffhunk://#diff-7c2ae0f3b1831efb1d74bf390f783222b696819854e2bca91e0ed721831a1227R3) [[2]](diffhunk://#diff-7c2ae0f3b1831efb1d74bf390f783222b696819854e2bca91e0ed721831a1227L39-R40) [[3]](diffhunk://#diff-7c2ae0f3b1831efb1d74bf390f783222b696819854e2bca91e0ed721831a1227L184-R186)