### PR TITLE
Add Environment enums

### DIFF
--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -46,6 +46,22 @@ export const DEVELOPMENT_STATS: ReadonlyArray<Stat> = ['Agility', 'Constitution'
 export type TreasureValueType = 'Very Poor' | 'Poor' | 'Normal' | 'Rich' | 'Very Rich' | 'Special';
 export const TREASUREVALUETYPES: ReadonlyArray<TreasureValueType> = ['Very Poor', 'Poor', 'Normal', 'Rich', 'Very Rich', 'Special'] as const;
 
+/** Enum for Environment features */
+export type EnvironmentFeature = 'Battlefield' | 'Burial' | 'Cave' | 'Cavern' | 'Dimention' | 'Enchanted' | 'Habitation' | 'Ruins' | 'Rural' | 'Volcanic';
+export const ENVIRONMENT_FEATURES: ReadonlyArray<EnvironmentFeature> = ['Battlefield', 'Burial', 'Cave', 'Cavern', 'Dimention', 'Enchanted', 'Habitation', 'Ruins', 'Rural', 'Volcanic'] as const;
+
+/** Enum for Environment terrain  */
+export type EnvironmentTerrain = 'Alpine' | 'Rough' | 'Underground' | 'Waste';
+export const ENVIRONMENT_TERRAINS: ReadonlyArray<EnvironmentTerrain> = ['Alpine', 'Rough', 'Underground', 'Waste'] as const;
+
+/** Enum for Environment vegetation */
+export type EnvironmentVegetation = 'Barren' | 'Coniferous' | 'Deciduous' | 'Grasslands' | 'Heath' | 'Jungle' | 'Plains' | 'Tundra';
+export const ENVIRONMENT_VEGETATIONS: ReadonlyArray<EnvironmentVegetation> = ['Barren', 'Coniferous', 'Deciduous', 'Grasslands', 'Heath', 'Jungle', 'Plains', 'Tundra'] as const;
+
+/** Enum for Environment water bodies */
+export type EnvironmentWaterBody = 'Breaks' | 'Desert' | 'Fresh Coast' | 'Glacier' | 'Islet' | 'Lake' | 'Marsh' | 'Oasis' | 'Ocean' | 'Salt Coast';
+export const ENVIRONMENT_WATER_BODIES: ReadonlyArray<EnvironmentWaterBody> = ['Breaks', 'Desert', 'Fresh Coast', 'Glacier', 'Islet', 'Lake', 'Marsh', 'Oasis', 'Ocean', 'Salt Coast'] as const;
+
 //** Enum for armour types  */
 export type ArmourType = 'AT 1' | 'AT 2' | 'AT 3' | 'AT 4' | 'AT 5' | 'AT 6' | 'AT 7' | 'AT 8' | 'AT 9' | 'AT 10' | 'AT 11' | 'AT 12' | 'AT 13' | 'AT 14' | 'AT 15' | 'AT 16' | 'AT 17' | 'AT 18' | 'AT 19' | 'AT 20';
 export const ARMOUR_TYPES: ReadonlyArray<ArmourType> = ['AT 1', 'AT 2', 'AT 3', 'AT 4', 'AT 5', 'AT 6', 'AT 7', 'AT 8', 'AT 9', 'AT 10', 'AT 11', 'AT 12', 'AT 13', 'AT 14', 'AT 15', 'AT 16', 'AT 17', 'AT 18', 'AT 19', 'AT 20'] as const;


### PR DESCRIPTION
This pull request adds new enums and constant arrays for various environment-related features to the `src/types/enum.ts` file. These additions provide structured types for environment features, terrain, vegetation, and water bodies, which will help standardize and simplify how these attributes are handled throughout the codebase.

New environment type definitions:

* Added `EnvironmentFeature` type and `ENVIRONMENT_FEATURES` array to represent different environment features such as 'Battlefield', 'Cave', and 'Volcanic'.
* Added `EnvironmentTerrain` type and `ENVIRONMENT_TERRAINS` array for terrain types like 'Alpine', 'Rough', and 'Waste'.
* Added `EnvironmentVegetation` type and `ENVIRONMENT_VEGETATIONS` array for vegetation types including 'Barren', 'Grasslands', and 'Jungle'.
* Added `EnvironmentWaterBody` type and `ENVIRONMENT_WATER_BODIES` array for water body types such as 'Lake', 'Ocean', and 'Marsh'.