### PR TITLE
Add button to auto-fit data table columns

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -54,6 +54,8 @@ function clearWidths(persistKey?: string) {
 export interface DataTableHandle {
   /** Clears persisted column widths and resets the current rendered widths. */
   resetColumnWidths: () => void;
+  /** Adjusts the widths of all columns to fit their content */
+  autoFitAllColumns: () => void;
 }
 
 export interface ColumnDef<T> {
@@ -222,16 +224,33 @@ const DataTableInner = <T,>(
   // Expose imperative API to parent
   useImperativeHandle(ref, (): DataTableHandle => ({
     resetColumnWidths: () => {
-      // 1) Clear persisted value
       clearWidths(persistKey);
-      // 2) Drop local state
       setColWidths({});
-      // 3) Optionally force a layout pass; most tables will auto-reflow
     },
-  }), [persistKey]);
+    autoFitAllColumns: () => {
+      const next: Record<string, number> = {};
+      for (const c of columns) {
+        const min = Math.max(60, c.minWidth ?? 80);
+        const max = Math.max(min, c.maxWidth ?? 800);
+        const natural = getMaxNaturalWidthInColumn(c.id);
+        const fitted = clamp(natural, min, max);
+        next[c.id] = fitted;
+      }
+      setColWidths(next);
+      if (onColumnResizeEnd) {
+        const out: Record<string, number | undefined> = {};
+        for (const c of columns) out[c.id] = next[c.id];
+        onColumnResizeEnd(out);
+      }
+    },
+  }), [persistKey, columns, onColumnResizeEnd]);
 
   // Optional convenience: also export a static helper for non-ref usage
   (DataTable as any).resetWidthsByPersistKey = (key: string) => clearWidths(key);
+  (DataTable as any).autoFitAllColumnsByPersistKey = (key: string) => {
+    // This is a no-op for non-ref usage, as we need the columns context
+    console.warn('autoFitAllColumnsByPersistKey is not supported without a ref');
+  };
 
   // When user resizes a column (wherever you implement drag handles), update and save:
   const onResizeColumn = (colId: string, widthPx: number) => {

--- a/src/endpoints/armourtype/ArmourTypeView.tsx
+++ b/src/endpoints/armourtype/ArmourTypeView.tsx
@@ -315,15 +315,9 @@ export default function ArmourTypeView() {
             placeholder="Search armour types…"
             aria-label="Search armour types"
           />
-          {/* Reset widths button */}
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/attacktable/AttackTableView.tsx
+++ b/src/endpoints/attacktable/AttackTableView.tsx
@@ -357,14 +357,9 @@ export default function AttacktablesView() {
             placeholder="Search attack tables…"
             aria-label="Search attack tables"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/book/BookView.tsx
+++ b/src/endpoints/book/BookView.tsx
@@ -258,14 +258,9 @@ export default function BookView() {
             placeholder="Search books…"
             aria-label="Search books"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/climate/ClimateView.tsx
+++ b/src/endpoints/climate/ClimateView.tsx
@@ -297,14 +297,9 @@ export default function ClimateView() {
             placeholder="Search climates…"
             aria-label="Search climates"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/creaturepace/CreaturePaceView.tsx
+++ b/src/endpoints/creaturepace/CreaturePaceView.tsx
@@ -304,14 +304,9 @@ export default function CreaturePaceView() {
             placeholder="Search creature paces…"
             aria-label="Search creature paces"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/disease/DiseaseView.tsx
+++ b/src/endpoints/disease/DiseaseView.tsx
@@ -303,14 +303,9 @@ export default function DiseaseView() {
             placeholder="Search diseases…"
             aria-label="Search diseases"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/diseasetype/DiseaseTypeView.tsx
+++ b/src/endpoints/diseasetype/DiseaseTypeView.tsx
@@ -321,14 +321,9 @@ export default function DiseaseTypeView() {
             placeholder="Search disease types…"
             aria-label="Search disease types"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/language/LanguageView.tsx
+++ b/src/endpoints/language/LanguageView.tsx
@@ -347,14 +347,9 @@ export default function LanguagesView() {
             placeholder="Search languages…"
             aria-label="Search languages"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/languagecategory/LanguageCategoryView.tsx
+++ b/src/endpoints/languagecategory/LanguageCategoryView.tsx
@@ -225,14 +225,9 @@ export default function LanguageCategoryView() {
             placeholder="Search language categories…"
             aria-label="Search language categories"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/poison/PoisonView.tsx
+++ b/src/endpoints/poison/PoisonView.tsx
@@ -293,14 +293,9 @@ export default function PoisonView() {
             placeholder="Search poisons…"
             aria-label="Search poisons"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/poisontype/PoisonTypeView.tsx
+++ b/src/endpoints/poisontype/PoisonTypeView.tsx
@@ -417,14 +417,9 @@ export default function PoisonTypeView() {
             placeholder="Search poison types…"
             aria-label="Search poison types"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/skill/SkillView.tsx
+++ b/src/endpoints/skill/SkillView.tsx
@@ -524,15 +524,9 @@ export default function SkillView() {
             aria-label="Search skills"
           />
 
-          {/* Reset widths button */}
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/skillcategory/SkillCategoryView.tsx
+++ b/src/endpoints/skillcategory/SkillCategoryView.tsx
@@ -416,14 +416,9 @@ export default function SkillCategoryView() {
             placeholder="Search skill categories…"
             aria-label="Search skill categories"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/skillgroup/SkillGroupView.tsx
+++ b/src/endpoints/skillgroup/SkillGroupView.tsx
@@ -228,14 +228,9 @@ export default function SkillGroupView() {
             placeholder="Search skill groups…"
             aria-label="Search skill groups"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/skillprogressiontype/SkillProgressionTypeView.tsx
+++ b/src/endpoints/skillprogressiontype/SkillProgressionTypeView.tsx
@@ -284,14 +284,9 @@ export default function SkillProgressionTypeView() {
             placeholder="Search skill progression types…"
             aria-label="Search skill progression types"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/specialattacktable/SpecialAttackTableView.tsx
+++ b/src/endpoints/specialattacktable/SpecialAttackTableView.tsx
@@ -358,15 +358,9 @@ export default function SpecialattacktablesView() {
             aria-label="Search special attack tables"
           />
 
-          {/* Reset widths button */}
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/spelllist/SpellListView.tsx
+++ b/src/endpoints/spelllist/SpellListView.tsx
@@ -342,14 +342,9 @@ export default function SpellListView() {
             placeholder="Search spell lists…"
             aria-label="Search spell lists"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 

--- a/src/endpoints/treasurecode/TreasureCodeView.tsx
+++ b/src/endpoints/treasurecode/TreasureCodeView.tsx
@@ -258,14 +258,9 @@ export default function TreasureCodeView() {
             placeholder="Search treasure codes…"
             aria-label="Search treasure codes"
           />
-          <button
-            type="button"
-            onClick={() => dtRef.current?.resetColumnWidths()}
-            title="Reset all column widths"
-            style={{ marginLeft: 'auto' }}
-          >
-            Reset column widths
-          </button>
+          {/* Reset and auto-fit column widths */}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 


### PR DESCRIPTION
This pull request enhances the usability of the `DataTable` component by adding a new "Auto-fit all columns" feature, allowing users to automatically adjust all column widths to fit their content. This new functionality is exposed both via the imperative API and as a button in various data table views across the application, alongside the existing "Reset column widths" option.

**DataTable component enhancements:**

* Added a new `autoFitAllColumns` method to the `DataTableHandle` interface, which adjusts all column widths to fit their content.
* Implemented the `autoFitAllColumns` logic within the `DataTableInner` component, ensuring column widths are clamped within their minimum and maximum values, and updating the state and any resize callbacks accordingly.
* Added a static placeholder for `autoFitAllColumnsByPersistKey` (currently a no-op for non-ref usage) to maintain API consistency.

**UI updates across endpoints:**

* Updated all relevant data table views (e.g., `ArmourTypeView`, `AttacktablesView`, `BookView`, `ClimateView`, `CreaturePaceView`, `DiseaseView`, `DiseaseTypeView`, `LanguagesView`, `LanguageCategoryView`, `PoisonView`, `PoisonTypeView`, `SkillView`, `SkillCategoryView`, `SkillGroupView`, `SkillProgressionTypeView`, `SpecialattacktablesView`, `SpellListView`, `TreasureCodeView`) to include an "Auto-fit all columns" button next to the existing "Reset column widths" button. This provides users with quick access to both column width management features. [[1]](diffhunk://#diff-4a77eaf6291bcdc64285cd78275fde916d3773f66dece3403bd891edb081ef66L318-R320) [[2]](diffhunk://#diff-cbaa16536a402befac75bcf5f0934732278925a957a58f69b67cbb6ba1a72459L360-R362) [[3]](diffhunk://#diff-4e365bdcda6d16619837d7d7f8518f089a442f33efad844d4cf433ea4a4865b3L261-R263) [[4]](diffhunk://#diff-c7721406eebbd84a8350c887d974c8115e6d081ac0dffaa36f1a70e8b61ae338L300-R302) [[5]](diffhunk://#diff-da035bbcee4dfa130a7ff1973bdd6646c1786008507ddd9446d8d94e375cd890L307-R309) [[6]](diffhunk://#diff-f57266d9f49def4c4df393304e4127fe91c9f305a7c6ea91629ff747a98edf48L306-R308) [[7]](diffhunk://#diff-c65014a51bd01265ba2592565f425b6bc7a743acb83cfd476cb159939b97f889L324-R326) [[8]](diffhunk://#diff-073816067d71aad3469502a3cac7a1b13d993be22395d2c18af9951efdff97edL350-R352) [[9]](diffhunk://#diff-95c01907a84d0412a7d4535ef19e0d449f7ce27a7a1ca5a3408c3b3ac45b8964L228-R230) [[10]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L296-R298) [[11]](diffhunk://#diff-15e44ab7ebaccd871d8dcb93a11073da9d4a3b11b167e06e4ff174b4dcfc0c33L420-R422) [[12]](diffhunk://#diff-27a3333f6a1c30411176edece0d0c417b684f429f00840e9803d3e10d59963a3L527-R529) [[13]](diffhunk://#diff-8a2618cc9db38550e5753eb91c737a77702a4aae4698826eec202f326f6e1faeL419-R421) [[14]](diffhunk://#diff-9467991998a41bd81dbb5b8b813508e727e903663665c675ab41eaf2c83546a5L231-R233) [[15]](diffhunk://#diff-0bdaa10636dc11d9d00772caa1b8ce20114a9833a9c80d26164451ca4f8d676aL287-R289) [[16]](diffhunk://#diff-9ccb85b87a7d533ca6729fd45c7a325f4d4b8f77435e30945bf4d8323947afa8L361-R363) [[17]](diffhunk://#diff-377d6f0ee4e3fb8fda2c19f43f8c247ed1aa7a4a9b4255559c0f6a43acb791b4L345-R347) [[18]](diffhunk://#diff-29059aff8e9b3703eba328400c34d3e28677f81f40a12cb489405dee818e8c21L261-R263)