### PR TITLE
Add control for skill category costs

### DIFF
--- a/src/components/inputs/IdCostListEditor.tsx
+++ b/src/components/inputs/IdCostListEditor.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { LabeledInput } from './LabeledInput';
+import { LabeledSelect } from './LabeledSelect';
+
+export type IdCostRowVM = {
+  category: string;
+  cost: string;
+};
+
+export interface IdCostListEditorProps {
+  title: string;
+  rows: IdCostRowVM[];
+  onChangeRows: (next: IdCostRowVM[]) => void;
+
+  /** Options for the category selector */
+  categoryOptions: Array<{ value: string; label: string }>;
+
+  loading?: boolean | undefined;
+  viewing?: boolean | undefined;
+  error?: string | undefined;
+
+  /** Optional labels */
+  categoryColumnLabel?: string | undefined;
+  costColumnLabel?: string | undefined;
+
+  /** Optional button labels */
+  addButtonLabel?: string | undefined;
+  removeButtonLabel?: string | undefined;
+
+  /** Optional width for the cost input */
+  costWidth?: number | string | undefined;
+}
+
+const sanitizeCost = (s: string): string => s.replace(/^[1-9]\d*(?::[1-9]\d*){0,2}$/g, '');
+
+export function IdCostListEditor({
+  title,
+  rows,
+  onChangeRows,
+  categoryOptions,
+  loading,
+  viewing,
+  error,
+  categoryColumnLabel = 'Category',
+  costColumnLabel = 'Cost',
+  addButtonLabel = '+ Add row',
+  removeButtonLabel = 'Remove',
+  costWidth = 140,
+}: IdCostListEditorProps) {
+  const resolvedCostWidth =
+    typeof costWidth === 'number' ? `${costWidth}px` : costWidth;
+
+  const updateRowAt = React.useCallback(
+    (index: number, patch: Partial<IdCostRowVM>) => {
+      const copy = rows.slice();
+
+      if (index < 0 || index >= copy.length) return;
+      const current = copy[index];
+      if (!current) return;
+
+      const nextRow: IdCostRowVM = {
+        category: patch.category ?? current.category,
+        cost: patch.cost ?? current.cost,
+      };
+
+      copy[index] = nextRow;
+      onChangeRows(copy);
+    },
+    [rows, onChangeRows],
+  );
+
+  const addRow = React.useCallback(() => {
+    const next: IdCostRowVM[] = [
+      ...rows,
+      {
+        category: '',
+        cost: '',
+      },
+    ];
+    onChangeRows(next);
+  }, [rows, onChangeRows]);
+
+  const removeRowAt = React.useCallback(
+    (index: number) => {
+      const copy = rows.slice();
+
+      if (index < 0 || index >= copy.length) return;
+      copy.splice(index, 1);
+
+      onChangeRows(copy);
+    },
+    [rows, onChangeRows],
+  );
+
+  return (
+    <section style={{ marginTop: 12 }}>
+      <h4 style={{ margin: '8px 0' }}>{title}</h4>
+
+      {!viewing && (
+        <button
+          type="button"
+          onClick={addRow}
+          style={{ marginBottom: 8 }}
+        >
+          {addButtonLabel}
+        </button>
+      )}
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(280px, 1fr) 160px auto',
+          gap: 8,
+        }}
+      >
+        <div style={{ fontWeight: 600 }}>{categoryColumnLabel}</div>
+        <div style={{ fontWeight: 600 }}>{costColumnLabel}</div>
+        <div />
+
+        {rows.map((row, i) => (
+          <React.Fragment key={`${title}-${i}`}>
+            <LabeledSelect
+              label={categoryColumnLabel}
+              hideLabel
+              ariaLabel={categoryColumnLabel}
+              value={row.category}
+              onChange={(v) => updateRowAt(i, { category: v })}
+              options={categoryOptions}
+              disabled={loading || viewing}
+            />
+
+            <LabeledInput
+              label={costColumnLabel}
+              hideLabel
+              ariaLabel={costColumnLabel}
+              value={row.cost}
+              onChange={(v) => updateRowAt(i, { cost: sanitizeCost(v) })}
+              disabled={viewing}
+              width={resolvedCostWidth}
+              helperText="e.g. 11 or 3:3:3"
+            />
+
+            {!viewing && (
+              <button
+                type="button"
+                onClick={() => removeRowAt(i)}
+                style={{ color: '#b00020' }}
+              >
+                {removeButtonLabel}
+              </button>
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+
+      {error && (
+        <div style={{ color: '#b00020', marginTop: 6 }}>
+          {error}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/endpoints/profession/ProfessionView.tsx
+++ b/src/endpoints/profession/ProfessionView.tsx
@@ -16,6 +16,7 @@ import { IdTypeListEditor } from '../../components/inputs/IdTypeListEditor';
 import { IdSubcategoryValueListEditor } from '../../components/inputs/IdSubcategoryValueListEditor';
 import { IdSubcategoryTypeListEditor } from '../../components/inputs/IdSubcategoryTypeListEditor';
 import { ChoiceListEditor } from '../../components/inputs/ChoiceListEditor';
+import { IdCostListEditor } from '../../components/inputs/IdCostListEditor';
 
 import { fetchProfessions, upsertProfession, deleteProfession } from '../../api/profession';
 import { fetchBooks } from '../../api/book';
@@ -739,20 +740,6 @@ export default function ProfessionView() {
     });
   };
 
-  const updateCategoryCostAt = (index: number, patch: Partial<CategoryCostVM>) => {
-    setForm((s) => {
-      const copy = s.skillCategoryCosts.slice();
-      if (index < 0 || index >= copy.length) return s;
-      const current = copy[index];
-      if (!current) return s;
-      copy[index] = {
-        category: patch.category ?? current.category,
-        cost: patch.cost ?? current.cost,
-      };
-      return { ...s, skillCategoryCosts: copy };
-    });
-  };
-
   const toggleStringInArray = (
     key: 'realms' | 'stats',
     value: string
@@ -1152,64 +1139,18 @@ export default function ProfessionView() {
           />
 
           {/* Skill Category Costs */}
-          <section style={{ marginTop: 12 }}>
-            <h4 style={{ margin: '8px 0' }}>Skill Category Costs</h4>
-            {!viewing && (
-              <button
-                type="button"
-                onClick={() => setForm((s) => ({
-                  ...s,
-                  skillCategoryCosts: [...s.skillCategoryCosts, { category: '', cost: '' }],
-                }))}
-                style={{ marginBottom: 8 }}
-              >
-                + Add category cost
-              </button>
-            )}
-
-            <div style={{ display: 'grid', gridTemplateColumns: 'minmax(280px, 1fr) 160px auto', gap: 8 }}>
-              <div style={{ fontWeight: 600 }}>Category</div>
-              <div style={{ fontWeight: 600 }}>Cost</div>
-              <div />
-              {form.skillCategoryCosts.map((r, i) => (
-                <React.Fragment key={`scc-${i}`}>
-                  <LabeledSelect
-                    label="Category"
-                    hideLabel
-                    value={r.category}
-                    onChange={(v) => updateCategoryCostAt(i, { category: v })}
-                    options={categoryOptions}
-                    disabled={categoriesLoading || viewing}
-                  />
-                  <LabeledInput
-                    label="Cost"
-                    hideLabel
-                    ariaLabel="Cost"
-                    value={r.cost}
-                    onChange={(v) => updateCategoryCostAt(i, { cost: v.replace(/[^0-9:]/g, '') })}
-                    disabled={viewing}
-                    width={140}
-                    helperText="e.g. 11 or 3:3:3"
-                  />
-                  {!viewing && (
-                    <button
-                      type="button"
-                      onClick={() => setForm((s) => {
-                        const copy = s.skillCategoryCosts.slice();
-                        if (i < 0 || i >= copy.length) return s;
-                        copy.splice(i, 1);
-                        return { ...s, skillCategoryCosts: copy };
-                      })}
-                      style={{ color: '#b00020' }}
-                    >
-                      Remove
-                    </button>
-                  )}
-                </React.Fragment>
-              ))}
-            </div>
-            {errors.skillCategoryCosts && <div style={{ color: '#b00020', marginTop: 6 }}>{errors.skillCategoryCosts}</div>}
-          </section>
+          <IdCostListEditor
+            title="Skill Category Costs"
+            rows={form.skillCategoryCosts}
+            onChangeRows={(next) =>
+              setForm((s) => ({ ...s, skillCategoryCosts: next }))
+            }
+            categoryOptions={categoryOptions}
+            loading={categoriesLoading}
+            viewing={viewing}
+            error={errors.skillCategoryCosts}
+            costWidth={140}
+          />
 
           <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
             {!viewing && <button onClick={saveForm} disabled={hasErrors}>Save</button>}


### PR DESCRIPTION
This pull request refactors the skill category cost editing functionality in the `ProfessionView` component by introducing a new reusable input component, `IdCostListEditor`. The change simplifies the code, improves maintainability, and enhances consistency across the codebase.

**Component extraction and refactoring:**

* Introduced a new component, `IdCostListEditor`, which encapsulates the logic and UI for editing lists of category/cost pairs. This component supports features like customizable labels, add/remove row functionality, loading and viewing modes, and error display. (`src/components/inputs/IdCostListEditor.tsx`)
* Replaced the previous inline implementation of the skill category cost editor in `ProfessionView` with the new `IdCostListEditor` component, removing now-unnecessary local handlers and UI code. (`src/endpoints/profession/ProfessionView.tsx`) [[1]](diffhunk://#diff-e814a8a1488823ed472eaa4f9e1db4fb803bd3691a1e4c0c2e5816e4b282f485L1155-L1212) [[2]](diffhunk://#diff-e814a8a1488823ed472eaa4f9e1db4fb803bd3691a1e4c0c2e5816e4b282f485L742-L755)
* Added the import for `IdCostListEditor` in `ProfessionView`. (`src/endpoints/profession/ProfessionView.tsx`)