### PR TITLE
Refactor somantic to somatic

### DIFF
--- a/src/api/language.ts
+++ b/src/api/language.ts
@@ -19,7 +19,7 @@ export async function fetchLanguages(): Promise<Language[]> {
     baseLanguage: x.baseLanguage != null ? asString(x.baseLanguage) : undefined,
     isSpoken: asBool((x as any).isSpoken),
     isWritten: asBool((x as any).isWritten),
-    isSomantic: asBool((x as any).isSomantic),
+    isSomatic: asBool((x as any).isSomatic),
   }));
 }
 

--- a/src/endpoints/language/LanguageView.tsx
+++ b/src/endpoints/language/LanguageView.tsx
@@ -22,7 +22,7 @@ type FormState = {
   baseLanguage?: string | undefined;
   isSpoken: boolean;
   isWritten: boolean;
-  isSomantic: boolean;
+  isSomatic: boolean;
 };
 
 const emptyVM = (): FormState => ({
@@ -32,7 +32,7 @@ const emptyVM = (): FormState => ({
   baseLanguage: '',
   isSpoken: false,
   isWritten: false,
-  isSomantic: false,
+  isSomatic: false,
 });
 
 const toVM = (x: Language): FormState => ({
@@ -42,7 +42,7 @@ const toVM = (x: Language): FormState => ({
   baseLanguage: x.baseLanguage ?? '',
   isSpoken: x.isSpoken,
   isWritten: x.isWritten,
-  isSomantic: x.isSomantic,
+  isSomatic: x.isSomatic,
 });
 
 const fromVM = (vm: FormState): Language => ({
@@ -52,7 +52,7 @@ const fromVM = (vm: FormState): Language => ({
   baseLanguage: vm.baseLanguage?.trim() ? vm.baseLanguage.trim() : undefined,
   isSpoken: !!vm.isSpoken,
   isWritten: !!vm.isWritten,
-  isSomantic: !!vm.isSomantic,
+  isSomatic: !!vm.isSomatic,
 });
 
 export default function LanguagesView() {
@@ -60,8 +60,8 @@ export default function LanguagesView() {
   const [rows, setRows] = useState<Language[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [errors, setErrors] = useState<{ id?: string | undefined; name?: string | undefined; category?: string | undefined; baseLanguage?: string | undefined; }>({});
-  const hasErrors = Boolean(errors.id || errors.name || errors.category || errors.baseLanguage);
+  const [errors, setErrors] = useState<{ id?: string | undefined; name?: string | undefined; category?: string | undefined; baseLanguage?: string | undefined; isSpoken?: string | undefined; isWritten?: string | undefined; isSomatic?: string | undefined; }>({});
+  const hasErrors = Boolean(errors.id || errors.name || errors.category || errors.baseLanguage || errors.isSpoken || errors.isWritten || errors.isSomatic);
 
   const [categories, setCategories] = useState<LanguageCategory[]>([]);
   const [catLoading, setCatLoading] = useState(true);
@@ -294,12 +294,12 @@ export default function LanguagesView() {
       render: (r) => (r.isWritten ? 'Yes' : 'No'),
     },
     {
-      id: 'isSomantic',
-      header: 'somantic',
-      accessor: (r) => Number(r.isSomantic),
+      id: 'isSomatic',
+      header: 'somatic',
+      accessor: (r) => Number(r.isSomatic),
       sortType: 'number',
       minWidth: 100,
-      render: (r) => (r.isSomantic ? 'Yes' : 'No'),
+      render: (r) => (r.isSomatic ? 'Yes' : 'No'),
     },
     {
       id: 'actions',
@@ -326,7 +326,7 @@ export default function LanguagesView() {
       r.baseLanguage ?? '',
       r.isSpoken ? 'yes' : 'no',
       r.isWritten ? 'yes' : 'no',
-      r.isSomantic ? 'yes' : 'no',
+      r.isSomatic ? 'yes' : 'no',
     ].some((v) => String(v ?? '').toLowerCase().includes(s));
   };
 
@@ -387,7 +387,7 @@ export default function LanguagesView() {
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
               <CheckboxInput label="Spoken" checked={form.isSpoken} onChange={(c) => setForm((s) => ({ ...s, isSpoken: c }))} disabled={viewing} />
               <CheckboxInput label="Written" checked={form.isWritten} onChange={(c) => setForm((s) => ({ ...s, isWritten: c }))} disabled={viewing} />
-              <CheckboxInput label="Somantic" checked={form.isSomantic} onChange={(c) => setForm((s) => ({ ...s, isSomantic: c }))} disabled={viewing} />
+              <CheckboxInput label="Somatic" checked={form.isSomatic} onChange={(c) => setForm((s) => ({ ...s, isSomatic: c }))} disabled={viewing} />
             </div>
           </div>
 

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -10,9 +10,16 @@ export interface Language {
   baseLanguage?: string | undefined;
   isSpoken: boolean;
   isWritten: boolean;
-  isSomantic: boolean;
+  isSomatic: boolean;
 }
 
 export interface LanguagesPayload {
   languages: Language[];
+}
+
+export interface LanguageRank {
+  language: string;               // Language.id
+  spoken: number;
+  written: number;
+  somatic?: number | undefined;  // keeping backend spelling
 }


### PR DESCRIPTION
This pull request corrects a spelling mistake throughout the codebase, changing all instances of the property name `isSomantic` to `isSomatic` in the language-related UI and API code. It also updates the error state and data table configurations to reflect this change, and introduces a new `LanguageRank` interface in the type definitions.

**Property renaming and consistency:**

* Changed all occurrences of `isSomantic` to `isSomatic` in the `Language` interface, form state, data transformation functions, and UI components in `LanguageView.tsx` and related files to ensure consistent naming. [[1]](diffhunk://#diff-073816067d71aad3469502a3cac7a1b13d993be22395d2c18af9951efdff97edL25-R25) [[2]](diffhunk://#diff-073816067d71aad3469502a3cac7a1b13d993be22395d2c18af9951efdff97edL35-R35) [[3]](diffhunk://#diff-073816067d71aad3469502a3cac7a1b13d993be22395d2c18af9951efdff97edL45-R45) [[4]](diffhunk://#diff-073816067d71aad3469502a3cac7a1b13d993be22395d2c18af9951efdff97edL55-R64) [[5]](diffhunk://#diff-073816067d71aad3469502a3cac7a1b13d993be22395d2c18af9951efdff97edL297-R302) [[6]](diffhunk://#diff-073816067d71aad3469502a3cac7a1b13d993be22395d2c18af9951efdff97edL329-R329) [[7]](diffhunk://#diff-073816067d71aad3469502a3cac7a1b13d993be22395d2c18af9951efdff97edL390-R390) [[8]](diffhunk://#diff-5431f9615e6f922135bf98497d4284753a4662626541804fe8d4799ec8b41902L22-R22) [[9]](diffhunk://#diff-f87be0a18223dd84f55144ad14a07c443e3015e08f72d033138daf69ec993a4aL13-R25)

* Updated the error state object and validation logic in `LanguageView.tsx` to include the new `isSomatic` field.

**Type definition updates:**

* Added a new `LanguageRank` interface to `src/types/language.ts`, which includes a `somatic` field (retaining the backend spelling for compatibility).