### PR TITLE
Do not show list components if list empty

### DIFF
--- a/src/components/inputs/ChoiceListEditor.tsx
+++ b/src/components/inputs/ChoiceListEditor.tsx
@@ -9,6 +9,7 @@ export function ChoiceListEditor<TType extends string = string, TOption = string
   onChangeRows,
   typeOptions,
   viewing,
+  showWhenEmpty = false,
   error,
   createEmptyOption,
   createEmptyRow,
@@ -142,6 +143,10 @@ export function ChoiceListEditor<TType extends string = string, TOption = string
     [rows, onChangeRows],
   );
 
+  // If we're in viewing mode, only show the component if there are rows or if showWhenEmpty is true
+  const showComponent = viewing ? rows.length > 0 || showWhenEmpty : true;
+  if (!showComponent) return null;
+
   return (
     <section style={{ marginTop: 12 }}>
       <h4 style={{ margin: '8px 0' }}>{title}</h4>
@@ -266,6 +271,9 @@ export interface ChoiceListEditorProps<TType extends string = string, TOption = 
 
   /** Whether the form is in view-only mode */
   viewing?: boolean | undefined;
+
+  /** Whether to show the component when viewing if there are no rows */
+  showWhenEmpty?: boolean | undefined;
 
   /** Validation error for the whole section */
   error?: string | undefined;

--- a/src/components/inputs/IdCostListEditor.tsx
+++ b/src/components/inputs/IdCostListEditor.tsx
@@ -17,6 +17,9 @@ export interface IdCostListEditorProps {
 
   loading?: boolean | undefined;
   viewing?: boolean | undefined;
+  /** Whether to show the component when viewing if there are no rows */
+  showWhenEmpty?: boolean | undefined;
+
   error?: string | undefined;
 
   /** Optional labels */
@@ -40,6 +43,7 @@ export function IdCostListEditor({
   categoryOptions,
   loading,
   viewing,
+  showWhenEmpty = false,
   error,
   categoryColumnLabel = 'Category',
   costColumnLabel = 'Cost',
@@ -93,6 +97,9 @@ export function IdCostListEditor({
   );
 
   const showActions = !viewing;
+
+  const showComponent = viewing ? rows.length > 0 || showWhenEmpty : true;
+  if (!showComponent) return null;
 
   return (
     <section style={{ marginTop: 12 }}>

--- a/src/components/inputs/IdListEditor.tsx
+++ b/src/components/inputs/IdListEditor.tsx
@@ -13,6 +13,9 @@ export interface IdListEditorProps<TId extends string = string> {
 
   loading?: boolean | undefined;
   viewing?: boolean | undefined;
+  /** Whether to show the component when viewing if there are no rows */
+  showWhenEmpty?: boolean | undefined;
+
   error?: string | undefined;
 
   /** Optional labels */
@@ -34,6 +37,7 @@ export function IdListEditor<TId extends string = string>({
   options,
   loading,
   viewing,
+  showWhenEmpty = false,
   error,
   columnLabel = 'Value',
   showLabels = false,
@@ -77,6 +81,9 @@ export function IdListEditor<TId extends string = string>({
     },
     [rows, onChangeRows],
   );
+
+  const showComponent = viewing ? rows.length > 0 || showWhenEmpty : true;
+  if (!showComponent) return null;
 
   return (
     <section style={{ marginTop: 12 }}>

--- a/src/components/inputs/IdTypeListEditor.tsx
+++ b/src/components/inputs/IdTypeListEditor.tsx
@@ -22,6 +22,9 @@ export interface IdTypeListEditorProps<
 
   loading?: boolean | undefined;
   viewing?: boolean | undefined;
+  /** Whether to show the component when viewing if there are no rows */
+  showWhenEmpty?: boolean | undefined;
+
   error?: string | undefined;
 
   /** Optional labels */
@@ -58,6 +61,7 @@ export function IdTypeListEditor<
   typeOptions,
   loading,
   viewing,
+  showWhenEmpty = false,
   error,
   idColumnLabel = 'ID',
   typeColumnLabel = 'Type',
@@ -119,6 +123,9 @@ export function IdTypeListEditor<
     },
     [rows, onChangeRows],
   );
+
+  const showComponent = viewing ? rows.length > 0 || showWhenEmpty : true;
+  if (!showComponent) return null;
 
   return (
     <section style={{ marginTop: 12 }}>

--- a/src/components/inputs/IdValueListEditor.tsx
+++ b/src/components/inputs/IdValueListEditor.tsx
@@ -18,6 +18,9 @@ export interface IdValueListEditorProps<TId extends string = string> {
 
   loading?: boolean | undefined;
   viewing?: boolean | undefined;
+  /** Whether to show the component when viewing if there are no rows */
+  showWhenEmpty?: boolean | undefined;
+
   error?: string | undefined;
 
   /** Column header labels */
@@ -53,6 +56,7 @@ export function IdValueListEditor<TId extends string = string>({
   options,
   loading,
   viewing,
+  showWhenEmpty = false,
   error,
   idColumnLabel = 'ID',
   valueColumnLabel = 'Value',
@@ -99,6 +103,10 @@ export function IdValueListEditor<TId extends string = string>({
   }, [rows, onChangeRows]);
 
   const showActions = !viewing;
+
+  const showComponent = viewing ? rows.length > 0 || showWhenEmpty : true;
+  if (!showComponent) return null;
+
   return (
     <section style={{ marginTop: 12 }}>
       <h4 style={{ margin: '8px 0' }}>{title}</h4>

--- a/src/components/inputs/SkillListEditor.tsx
+++ b/src/components/inputs/SkillListEditor.tsx
@@ -18,6 +18,9 @@ export interface SkillListEditorProps {
 
   loading?: boolean | undefined;
   viewing?: boolean | undefined;
+  /** Whether to show the component when viewing if there are no rows */
+  showWhenEmpty?: boolean | undefined;
+
   error?: string | undefined;
 
   /** Optional labels */
@@ -49,6 +52,7 @@ export function SkillListEditor({
   idOptions,
   loading,
   viewing,
+  showWhenEmpty = false,
   error,
   idColumnLabel = 'ID',
   subcategoryColumnLabel = 'Subcategory',
@@ -105,6 +109,9 @@ export function SkillListEditor({
     },
     [rows, onChangeRows],
   );
+
+  const showComponent = viewing ? rows.length > 0 || showWhenEmpty : true;
+  if (!showComponent) return null;
 
   return (
     <section style={{ marginTop: 12 }}>

--- a/src/components/inputs/SkillTypeListEditor.tsx
+++ b/src/components/inputs/SkillTypeListEditor.tsx
@@ -21,6 +21,9 @@ export interface SkillTypeListEditorProps<TType extends string = string> {
 
   loading?: boolean | undefined;
   viewing?: boolean | undefined;
+  /** Whether to show the component when viewing if there are no rows */
+  showWhenEmpty?: boolean | undefined;
+
   error?: string | undefined;
 
   /** Optional labels */
@@ -55,6 +58,7 @@ export function SkillTypeListEditor<TType extends string = string>({
   typeOptions,
   loading,
   viewing,
+  showWhenEmpty = false,
   error,
   idColumnLabel = 'ID',
   subcategoryColumnLabel = 'Subcategory',
@@ -121,6 +125,9 @@ export function SkillTypeListEditor<TType extends string = string>({
   );
 
   const showActions = !viewing;
+
+  const showComponent = viewing ? rows.length > 0 || showWhenEmpty : true;
+  if (!showComponent) return null;
 
   return (
     <section style={{ marginTop: 12 }}>

--- a/src/components/inputs/SkillValueListEditor.tsx
+++ b/src/components/inputs/SkillValueListEditor.tsx
@@ -20,6 +20,9 @@ export interface SkillValueListEditorProps {
 
   loading?: boolean | undefined;
   viewing?: boolean | undefined;
+  /** Whether to show the component when viewing if there are no rows */
+  showWhenEmpty?: boolean | undefined;
+
   error?: string | undefined;
 
   /** Optional labels */
@@ -57,6 +60,7 @@ export function SkillValueListEditor({
   idOptions,
   loading,
   viewing,
+  showWhenEmpty = false,
   error,
   idColumnLabel = 'ID',
   subcategoryColumnLabel = 'Subcategory',
@@ -115,6 +119,9 @@ export function SkillValueListEditor({
   );
 
   const showActions = !viewing;
+
+  const showComponent = viewing ? rows.length > 0 || showWhenEmpty : true;
+  if (!showComponent) return null;
 
   return (
     <section style={{ marginTop: 12 }}>


### PR DESCRIPTION
This pull request introduces a new prop, `showWhenEmpty`, to several list editor components. This prop allows the components to be displayed in viewing mode even when there are no rows, providing more flexibility for how empty lists are rendered in read-only contexts. The default behavior remains unchanged unless `showWhenEmpty` is explicitly set.

The most important changes are:

**New Feature: showWhenEmpty Prop**
- Added a `showWhenEmpty` prop (defaulting to `false`) to the props interfaces and function signatures of the following components: `ChoiceListEditor`, `IdCostListEditor`, `IdListEditor`, `IdTypeListEditor`, `IdValueListEditor`, `SkillListEditor`, `SkillTypeListEditor`, and `SkillValueListEditor`. This prop controls whether the component is rendered in viewing mode when there are no rows. [[1]](diffhunk://#diff-b4cd2c39a17c3a72db33b0a7935ea1a9569188ee13a6a53df2568dd50dd387bcR275-R277) [[2]](diffhunk://#diff-4710fab2b469138f61d84b82a26084d9c833b300166895f7ad0456ad7f0fd23aR20-R22) [[3]](diffhunk://#diff-bfdc21fff0bc1ad43b95738bdb897c200bd0209a458015a0e78c57c268fd8c3fR16-R18) [[4]](diffhunk://#diff-c1746a410b2dd826ba512e67123040eb653ccf86f09309c6732612dacdc63942R25-R27) [[5]](diffhunk://#diff-01ff435e22d9197ff5d218b56ec29d348cb458ca58795b13e26c25083f285564R21-R23) [[6]](diffhunk://#diff-583cb7b42773d32e7442ab323cc061bab5f8057c3eb0bf30c179752aecbbfdadR21-R23) [[7]](diffhunk://#diff-23749a10d34a615f61e1ba9dfd96ae22175be1aa185f692805598c68148933fcR24-R26) [[8]](diffhunk://#diff-1ec4c7df524ba6cae4cee79b9ee3fc53a83aa63b59807fcbbdef88d3d6ca3cadR23-R25)

**Conditional Rendering Logic**
- Updated each component to conditionally render based on the `showWhenEmpty` prop: if in viewing mode, the component will only render if there are rows or if `showWhenEmpty` is `true`; otherwise, it will not render. [[1]](diffhunk://#diff-b4cd2c39a17c3a72db33b0a7935ea1a9569188ee13a6a53df2568dd50dd387bcR146-R149) [[2]](diffhunk://#diff-4710fab2b469138f61d84b82a26084d9c833b300166895f7ad0456ad7f0fd23aR101-R103) [[3]](diffhunk://#diff-bfdc21fff0bc1ad43b95738bdb897c200bd0209a458015a0e78c57c268fd8c3fR85-R87) [[4]](diffhunk://#diff-c1746a410b2dd826ba512e67123040eb653ccf86f09309c6732612dacdc63942R127-R129) [[5]](diffhunk://#diff-01ff435e22d9197ff5d218b56ec29d348cb458ca58795b13e26c25083f285564R106-R109) [[6]](diffhunk://#diff-583cb7b42773d32e7442ab323cc061bab5f8057c3eb0bf30c179752aecbbfdadR113-R115) [[7]](diffhunk://#diff-23749a10d34a615f61e1ba9dfd96ae22175be1aa185f692805598c68148933fcR129-R131) [[8]](diffhunk://#diff-1ec4c7df524ba6cae4cee79b9ee3fc53a83aa63b59807fcbbdef88d3d6ca3cadR123-R125)

**Component Propagation**
- Passed the new `showWhenEmpty` prop through the destructuring of props in each component's function signature, ensuring the prop can be set by parent components and defaults to `false`. [[1]](diffhunk://#diff-b4cd2c39a17c3a72db33b0a7935ea1a9569188ee13a6a53df2568dd50dd387bcR12) [[2]](diffhunk://#diff-4710fab2b469138f61d84b82a26084d9c833b300166895f7ad0456ad7f0fd23aR46) [[3]](diffhunk://#diff-bfdc21fff0bc1ad43b95738bdb897c200bd0209a458015a0e78c57c268fd8c3fR40) [[4]](diffhunk://#diff-c1746a410b2dd826ba512e67123040eb653ccf86f09309c6732612dacdc63942R64) [[5]](diffhunk://#diff-01ff435e22d9197ff5d218b56ec29d348cb458ca58795b13e26c25083f285564R59) [[6]](diffhunk://#diff-583cb7b42773d32e7442ab323cc061bab5f8057c3eb0bf30c179752aecbbfdadR55) [[7]](diffhunk://#diff-23749a10d34a615f61e1ba9dfd96ae22175be1aa185f692805598c68148933fcR61) [[8]](diffhunk://#diff-1ec4c7df524ba6cae4cee79b9ee3fc53a83aa63b59807fcbbdef88d3d6ca3cadR63)

These changes improve the flexibility and usability of the list editor components in read-only scenarios.