### PR TITLE
Update componenets to use shared sanitisers

### DIFF
--- a/src/components/inputs/IdMultiSkillRankEditor.tsx
+++ b/src/components/inputs/IdMultiSkillRankEditor.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { LabeledInput } from './LabeledInput';
 import { LabeledSelect } from './LabeledSelect';
 
+import { sanitizeUnsignedInt } from '../../utils';
+
 export type IdMultiSkillRankRowVM<TId extends string = string> = {
   id: TId | '';
   value: string;
@@ -33,8 +35,6 @@ export interface IdMultiSkillRankEditorProps<TId extends string = string> {
   /** Layout */
   idColumnMinWidth?: number | string | undefined;
 }
-
-const sanitizeUnsignedInt = (s: string) => s.replace(/[^\d]/g, '');
 
 export function IdMultiSkillRankEditor<TId extends string = string>({
   title,

--- a/src/components/inputs/LanguageChoiceEditor.tsx
+++ b/src/components/inputs/LanguageChoiceEditor.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { LabeledInput } from './LabeledInput';
 
+import { LabeledInput } from './LabeledInput';
 import { LabeledSelect } from './LabeledSelect';
+
+import { sanitizeUnsignedInt } from '../../utils';
 
 export type LanguageChoiceRowVM<TLanguageId extends string = string> = {
   numChoices: string;
@@ -30,8 +32,6 @@ export interface LanguageChoiceEditorProps<TLanguageId extends string = string> 
   addRowLabel?: string | undefined;
   removeRowLabel?: string | undefined;
 }
-
-const sanitizeUnsignedInt = (s: string) => s.replace(/[^\d]/g, '');
 
 export function LanguageChoiceEditor<TLanguageId extends string = string>({
   title,

--- a/src/components/inputs/SpellListCategoryRankEditor.tsx
+++ b/src/components/inputs/SpellListCategoryRankEditor.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { LabeledInput } from './LabeledInput';
 import { LabeledSelect } from './LabeledSelect';
 
+import { sanitizeUnsignedInt } from '../../utils';
+
 export type SpellListCategoryRankRowVM<TCategoryId extends string = string> = {
   value: string;        // ranks
   numChoices: string;   // number of choices
@@ -25,8 +27,6 @@ export interface SpellListCategoryRankEditorProps<
   addRowLabel?: string | undefined;
   removeRowLabel?: string | undefined;
 }
-
-const sanitizeUnsignedInt = (s: string) => s.replace(/[^\d]/g, '');
 
 export function SpellListCategoryRankEditor<
   TCategoryId extends string = string

--- a/src/components/inputs/SpellListRankEditor.tsx
+++ b/src/components/inputs/SpellListRankEditor.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { LabeledInput } from './LabeledInput';
 import { LabeledSelect } from './LabeledSelect';
 
+import { sanitizeUnsignedInt } from '../../utils';
+
 export type SpellListRankRowVM<
   TCategoryId extends string = string,
   TSpellListId extends string = string
@@ -33,8 +35,6 @@ export interface SpellListRankEditorProps<
   addRowLabel?: string | undefined;
   removeRowLabel?: string | undefined;
 }
-
-const sanitizeUnsignedInt = (s: string) => s.replace(/[^\d]/g, '');
 
 export function SpellListRankEditor<
   TCategoryId extends string = string,


### PR DESCRIPTION
This pull request refactors how the `sanitizeUnsignedInt` utility function is used across several input editor components. The main improvement is referencing the existing function in the shared utility location and updating all relevant components to import it from there, reducing code duplication and improving maintainability.

**Refactoring and Code Reuse:**

* Moved the `sanitizeUnsignedInt` function to `src/utils` and updated its import in the following components, removing local duplicate definitions: `IdMultiSkillRankEditor.tsx`, `LanguageChoiceEditor.tsx`, `SpellListCategoryRankEditor.tsx`, and `SpellListRankEditor.tsx`. [[1]](diffhunk://#diff-cf9b71cec6f4008faf333d8f450bf80de4a07d59c3312973806690e8f4a6b3c1R5-R6) [[2]](diffhunk://#diff-cf9b71cec6f4008faf333d8f450bf80de4a07d59c3312973806690e8f4a6b3c1L37-L38) [[3]](diffhunk://#diff-e43b5fa2556b5da68648e15b2e75f76a865aaae682546fac00d11edc1c843846L2-R7) [[4]](diffhunk://#diff-e43b5fa2556b5da68648e15b2e75f76a865aaae682546fac00d11edc1c843846L34-L35) [[5]](diffhunk://#diff-62f82db61677f4a232134ef87a7078858f82c9d9b2d0633eb2393242d75c409dR5-R6) [[6]](diffhunk://#diff-62f82db61677f4a232134ef87a7078858f82c9d9b2d0633eb2393242d75c409dL29-L30) [[7]](diffhunk://#diff-eac7e68b3c15f20ea8406ccedbaf8a023589690bebbbacd0d796d4e7b75f6048R5-R6) [[8]](diffhunk://#diff-eac7e68b3c15f20ea8406ccedbaf8a023589690bebbbacd0d796d4e7b75f6048L37-L38)