### PR TITLE
Add Spinner component

### DIFF
--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,10 @@
+
+export function Spinner({ size = 16 }: { size?: number }) {
+  return (
+    <span
+      className="spinner"
+      style={{ width: size, height: size }}
+      aria-hidden
+    />
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './ConfirmDialog';
 export * from './DataTable';
 export * from './Sidebar';
+export * from './Spinner';
 export * from './ThemeProvider';
 export * from './Toast';
 export * from './inputs';

--- a/src/layout.css
+++ b/src/layout.css
@@ -412,3 +412,34 @@ body.theme-dark tr:nth-child(even) {
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+/* Optional: add a subtle overlay to indicate non-interactive state */
+.form-container {
+  position: relative;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  z-index: 10;
+}
+
+/* Simple spinner for loading state */
+.spinner {
+  display: inline-block;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-top-color: rgba(0, 0, 0, 0.8);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
This pull request introduces a reusable `Spinner` component and supporting CSS for loading and non-interactive UI states. It also makes the new component available for import throughout the codebase.

Component addition:

* Added a new `Spinner` component in `src/components/Spinner.tsx` for displaying a loading indicator, with customizable size.
* Exported the `Spinner` component from the main components index for easy usage elsewhere in the project (`src/components/index.ts`).

Styling enhancements:

* Added CSS styles in `src/layout.css` for the `.spinner` class, a keyframes animation for spinning, and styles for `.overlay` and `.form-container` to visually indicate loading or disabled states in forms.