### PR TITLE
Add PillList component

### DIFF
--- a/src/components/PillList.tsx
+++ b/src/components/PillList.tsx
@@ -1,0 +1,59 @@
+type PillProps = {
+  label: string;
+};
+
+/**
+ * A simple pill component to display a label in a compact form.
+ * @prop label The text to display inside the pill.
+ * The pill has a border, background color, and rounded corners. It also has a tooltip that shows the full label when hovered.
+ */
+export function Pill({ label }: PillProps) {
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        marginRight: 6,
+        marginBottom: 4,
+        borderRadius: 999,
+        fontSize: 12,
+        border: '1px solid var(--border)',
+        background: 'var(--panel)',
+        whiteSpace: 'nowrap',
+      }}
+      title={label}
+    >
+      {label}
+    </span>
+  );
+}
+
+type PillListProps<T extends string> = {
+  values: T[];
+  getLabel?: (value: T) => string;
+  emptyLabel?: string;
+};
+
+/**
+ * A component to display a list of values as pills. If the list is empty, it displays an optional empty label.
+ * @param values The list of values to display as pills.
+ * @param getLabel A function to get the label for each value. Defaults to the value itself.
+ * @param emptyLabel The label to display when the list is empty. Defaults to '—'.
+ */
+export function PillList<T extends string>({
+  values,
+  getLabel = v => v,
+  emptyLabel = '—',
+}: PillListProps<T>) {
+  if (values.length === 0) {
+    return <span style={{ color: 'var(--muted)' }}>{emptyLabel}</span>;
+  }
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+      {values.map(value => (
+        <Pill key={value} label={getLabel(value)} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './ConfirmDialog';
 export * from './DataTable';
+export * from './PillList';
 export * from './Sidebar';
 export * from './Spinner';
 export * from './ThemeProvider';


### PR DESCRIPTION
This pull request introduces a new reusable UI component for displaying lists of pill-shaped labels and makes it available for use throughout the project.

New pill list UI component:

* Added a new `PillList` component in `src/components/PillList.tsx` that displays a list of values as pill-shaped labels, with support for custom labeling and an empty state. Also includes a `Pill` subcomponent for rendering individual pills.

Component exports:

* Exported the new `PillList` component from the main components index file (`src/components/index.ts`) to make it accessible throughout the codebase.