### PR TITLE
Update CreatureType to use PillList component

### DIFF
--- a/src/endpoints/climate/ClimateView.tsx
+++ b/src/endpoints/climate/ClimateView.tsx
@@ -9,6 +9,7 @@ import {
   CheckboxGroup,
   LabeledInput,
   LabeledSelect,
+  PillList,
   Spinner,
   useConfirm, useToast,
 } from '../../components';
@@ -171,18 +172,9 @@ export default function ClimateView() {
       minWidth: 140,
     },
     {
-      id: 'precipitations',
-      header: 'Precipitations',
+      id: 'precipitations', header: 'Precipitations', minWidth: 220,
       accessor: (r) => r.precipitations.join(', '),
-      sortType: 'string',
-      minWidth: 220,
-      render: (r) => (
-        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-          {r.precipitations.length === 0
-            ? <span style={{ color: 'var(--muted)' }}>—</span>
-            : r.precipitations.map(pill)}
-        </div>
-      ),
+      render: r => (<PillList values={r.precipitations} />),
     },
     {
       id: 'actions',


### PR DESCRIPTION
This pull request makes a targeted UI improvement to the `ClimateView` table by refactoring how precipitation values are displayed. The main change is the replacement of custom rendering logic with the reusable `PillList` component for the `precipitations` column, streamlining the code and enhancing consistency.

UI Refactoring:

* Updated the `precipitations` column in `ClimateView` to use the `PillList` component for rendering precipitation values, replacing the previous inline rendering logic. This improves code maintainability and visual consistency across the application.
* Added `PillList` to the imports from `../../components` in `ClimateView.tsx`.