### PR TITLE
Update Poison with latest features

### DIFF
--- a/src/endpoints/poison/PoisonView.tsx
+++ b/src/endpoints/poison/PoisonView.tsx
@@ -9,6 +9,7 @@ import {
   DataTable, type DataTableHandle, DataTableSearchInput, type ColumnDef,
   LabeledInput,
   LabeledSelect,
+  Spinner,
   useConfirm, useToast,
 } from '../../components'
 
@@ -24,17 +25,63 @@ import {
 
 const prefix = 'POISON_';
 
-function emptyPoison(): Poison {
-  return { id: prefix, name: '', type: '', level: 0, levelVariance: '' };
+/* ------------------------------------------------------------------ */
+/* VM types                                                           */
+/* ------------------------------------------------------------------ */
+type FormState = {
+  id: string;
+  name: string;
+  type: string;
+  level: number | '';
+  levelVariance: string;
 }
+
+type FormErrors = {
+  id?: string;
+  name?: string;
+  type?: string;
+  level?: string;
+  variance?: string;
+}
+
+const emptyVM = (): FormState => ({
+  id: prefix,
+  name: '',
+  type: '',
+  level: '',
+  levelVariance: '',
+});
+
+const toVM = (p: Poison): FormState => ({
+  id: p.id,
+  name: p.name,
+  type: p.type,
+  level: p.level,
+  levelVariance: p.levelVariance,
+});
+
+const fromVM = (vm: FormState): Poison => ({
+  id: vm.id.trim(),
+  name: vm.name.trim(),
+  type: vm.type.trim(),
+  level: Number(vm.level),
+  levelVariance: vm.levelVariance.trim(),
+});
+
+/* ------------------------------------------------------------------ */
+/* View                                                               */
+/* ------------------------------------------------------------------ */
 
 export default function PoisonView() {
   const dtRef = useRef<DataTableHandle>(null);
+
   const [rows, setRows] = useState<Poison[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [errors, setErrors] = useState<{ id?: string; name?: string; type?: string; level?: string; variance?: string }>({});
-  const hasErrors = Boolean(errors.id || errors.name || errors.type || errors.level || errors.variance);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const hasErrors = Object.values(errors).some(Boolean);
+
+  const [poisonTypes, setPoisonTypes] = useState<PoisonType[]>([]);
 
   const [query, setQuery] = useState('');
   const [page, setPage] = useState(1);
@@ -44,72 +91,84 @@ export default function PoisonView() {
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [viewing, setViewing] = useState(false);
-  const [form, setForm] = useState<Poison>(emptyPoison());
-
-  // Form state for loading the select options for poison types (if needed in the future)
-  const [poisonTypes, setPoisonTypes] = useState<PoisonType[]>([]);
-  const [typesLoading, setTypesLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyVM());
 
   const toast = useToast();
   const confirm = useConfirm();
 
-  // ----- Load Poisons -----
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        const poisons = await fetchPoisons();
-        if (!mounted) return;
-        setRows(poisons);
-      } catch (err) {
-        if (!mounted) return;
-        setError(err instanceof Error ? err.message : String(err));
-      } finally {
-        if (mounted) setLoading(false);
-      }
-    })();
-    return () => { mounted = false; };
-  }, []);
+  /* ------------------------------------------------------------------ */
+  /* Load data                                                          */
+  /* ------------------------------------------------------------------ */
 
-  // ----- Load Poison Types -----
   useEffect(() => {
-    let mounted = true;
     (async () => {
       try {
-        const pts = await fetchPoisontypes();
-        if (!mounted) return;
-        setPoisonTypes(pts);
+        const [p, pt] = await Promise.all([
+          fetchPoisons(),
+          fetchPoisontypes(),
+
+        ]);
+        setRows(p);
+        setPoisonTypes(pt);
       } catch (e) {
-        // If this fails, we’ll still render the form, but save-time validation will catch invalid types.
-        console.error('Failed to load PoisonTypes', e);
+        setError(String(e));
       } finally {
-        if (mounted) setTypesLoading(false);
+        setLoading(false);
       }
     })();
-    return () => { mounted = false; };
   }, []);
-  const poisonTypeIds = useMemo(() => new Set(poisonTypes.map(pt => pt.id)), [poisonTypes]);
 
-  // ----- Inline validation helpers -----
-  const computeErrors = (draft: Poison) => {
-    const next: { id?: string; name?: string; type?: string; level?: string; variance?: string } = {};
+  /* ------------------------------------------------------------------ */
+  /* Helpers                                                            */
+  /* ------------------------------------------------------------------ */
+  const poisonTypeIds = useMemo(() =>
+    new Set(poisonTypes.map(pt => pt.id)),
+    [poisonTypes]
+  );
+
+  const poisonTypeById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const pt of poisonTypes) m.set(pt.id, pt.type);
+    return m;
+  },
+    [poisonTypes]
+  );
+
+  const poisonTypeOptions = useMemo(() =>
+    poisonTypes.map((pt) => ({ value: pt.id, label: `${pt.type}`, })),
+    [poisonTypes]
+  );
+
+
+  /* ------------------------------------------------------------------ */
+  /* Validation                                                         */
+  /* ------------------------------------------------------------------ */
+
+  const computeErrors = (draft: FormState): FormErrors => {
+    const e: FormErrors = {};
+
     // ID (only on create, must be unique and start with prefix in ucase and contain additional characters)
-    if (!draft.id.trim()) next.id = 'ID is required';
-    else if (!editingId && rows.some(r => r.id === draft.id.trim())) next.id = `ID "${draft.id.trim()}" already exists`;
-    else if (!isValidID(draft.id, prefix)) next.id = `ID must start with "${prefix}" and contain additional characters`;
+    if (!draft.id.trim()) e.id = 'ID is required';
+    else if (!editingId && rows.some(r => r.id === draft.id.trim())) e.id = `ID "${draft.id.trim()}" already exists`;
+    else if (!isValidID(draft.id, prefix)) e.id = `ID must start with "${prefix}" and contain additional characters`;
+
     // Name
-    if (!draft.name.trim()) next.name = 'Name is required';
+    if (!draft.name.trim()) e.name = 'Name is required';
+
     // Type
-    if (!draft.type.trim()) next.type = 'Type is required';
-    else if (!poisonTypeIds.has(draft.type.trim())) next.type = `Type "${draft.type.trim()}" is not a valid PoisonType id`;
+    if (!draft.type.trim()) e.type = 'Type is required';
+    else if (!poisonTypeIds.has(draft.type.trim())) e.type = `Type "${draft.type.trim()}" is not a valid PoisonType id`;
+
     // Level (must be a number, but allow empty string for controlled input)
     const raw = (draft.level ?? '').toString().trim();
-    if (!isValidUnsignedInt(raw)) next.level = `Level must be an integer`;
-    // Variance must be a single uppercase character
-    if (!draft.levelVariance.trim()) next.variance = `Level Variance is required`;
-    else if (!/^[A-H]$/.test(draft.levelVariance.trim())) next.variance = 'Level Variance must be a single uppercase character between A and H';
+    if (!isValidUnsignedInt(raw)) e.level = `Level must be an integer`;
 
-    return next;
+    // Variance must be a single uppercase character
+    if (!draft.levelVariance.trim()) e.variance = `Level Variance is required`;
+    else if (!/^[A-H]$/.test(draft.levelVariance.trim())) e.variance = 'Level Variance must be a single uppercase character between A and H';
+
+    return e;
   };
 
   useEffect(() => {
@@ -117,143 +176,15 @@ export default function PoisonView() {
     setErrors(computeErrors(form));
   }, [form, showForm, viewing]); // keep current for live validation
 
-  // ----- Handlers (Create / Edit / Delete) -----
-  const startNew = () => {
-    setViewing(false);
-    setEditingId(null);
-    setForm(emptyPoison());
-    setErrors({});
-    setShowForm(true);
-  };
 
-  const startEdit = (row: Poison) => {
-    setViewing(false);
-    setEditingId(row.id);
-    setForm({ ...row });
-    setErrors({});
-    setShowForm(true);
-  };
-
-  const startDuplicate = (row: Poison) => {
-    setViewing(false);
-    setEditingId(null);
-
-    const next = { ...row };
-    next.id = prefix; // reset ID to prefix for user to edit (enforce new ID)
-    next.name += ' (Copy)';
-
-    setForm(next); // if your form state = Poison
-    setErrors?.({});      // if you have an errors object
-    setShowForm(true);
-  };
-
-  const startView = (row: Poison) => {
-    setViewing(true);
-    setEditingId(row.id);       // we can reuse editingId to preload the item, but we won't allow saving
-    setForm({ ...row });
-    setErrors({});              // no need to compute field errors for read-only view, but we can keep formErr for any potential top-level messages
-    setShowForm(true);
-  };
-
-  const cancelForm = () => {
-    setViewing(false);
-    setShowForm(false);
-    setEditingId(null);
-    setErrors({});
-  };
-
-  const saveForm = async () => {
-    // Normalize payload to Poison while ensuring number coercion for level
-    const payload: Poison = {
-      id: String(form.id).trim(),
-      name: String(form.name).trim(),
-      type: String(form.type).trim(),
-      level: Number(form.level),            // ensure number
-      levelVariance: String(form.levelVariance).trim(),
-    };
-
-    const nextErrors = computeErrors(form);
-    setErrors(nextErrors);
-    if (hasErrors) return;
-
-    const isEditing = Boolean(editingId);
-    try {
-      const opts = editingId
-        ? { method: 'PUT' as const, useResourceIdPath: true }
-        : { method: 'POST' as const, useResourceIdPath: false };
-
-      await upsertPoison(payload, opts);
-
-      setRows((prev) => {
-        if (isEditing) {
-          // replace existing row
-          const idx = prev.findIndex((r) => r.id === payload.id);
-          if (idx >= 0) {
-            const copy = [...prev];
-            copy[idx] = { ...copy[idx], ...payload };
-            return copy;
-          }
-          // fallback: if not found (rare), prepend
-          return [payload, ...prev];
-        }
-        // create → prepend
-        return [payload, ...prev];
-      });
-
-      setShowForm(false);
-      setEditingId(null);
-      toast({
-        variant: 'success',
-        title: isEditing ? 'Updated' : 'Saved',
-        description: `Poison "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
-      });
-    } catch (err) {
-      toast({
-        variant: 'danger',
-        title: 'Save failed',
-        description: String(err instanceof Error ? err.message : err),
-      });
-    }
-  };
-
-  const onDelete = async (row: Poison) => {
-    const id = row?.id;
-    if (!id) return;
-    const ok = await confirm({
-      title: 'Delete Poison',
-      body: `Delete poison "${id}"? This cannot be undone.`,
-      confirmText: 'Delete',
-      cancelText: 'Cancel',
-      tone: 'danger',
-    });
-    if (!ok) return;
-
-    const prev = rows;
-    setRows(prev.filter((p) => p.id !== id));
-    try {
-      await deletePoison(id);
-      // if currently editing this item, close the form
-      if (editingId === row.id) cancelForm();
-      toast({ variant: 'success', title: 'Deleted', description: `Poison "${id}" deleted.` });
-    } catch (err) {
-      setRows(prev);
-      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err) });
-    }
-  };
-
-  // Display the human-friendly PoisonType.type instead of the raw Poison.type id in the table, using a memoized map for efficient lookup
-  const poisonTypeLabelById = useMemo(() => {
-    const m = new Map<string, string>();
-    for (const pt of poisonTypes) m.set(pt.id, pt.type);
-    return m;
-  }, [poisonTypes]);
-
-  // ----- Columns (Edit + Delete) -----
+  /* ------------------------------------------------------------------ */
+  /* Table                                                              */
+  /* ------------------------------------------------------------------ */
   const columns: ColumnDef<Poison>[] = useMemo(() => {
     return [
       { id: 'id', header: 'ID', accessor: (r) => r.id, sortType: 'string', minWidth: 220 },
       { id: 'name', header: 'Name', accessor: (r) => r.name, sortType: 'string', minWidth: 180 },
-      { id: 'type', header: 'Type', accessor: (r) => r.type, sortType: 'string', render: (r) => poisonTypeLabelById.get(r.type) ?? r.type, minWidth: 180 },
+      { id: 'type', header: 'Type', accessor: (r) => r.type, sortType: 'string', render: (r) => poisonTypeById.get(r.type) ?? r.type, minWidth: 180 },
       { id: 'level', header: 'Level', accessor: r => r.level, sortType: 'number', align: 'center', minWidth: 80 },
       { id: 'levelVariance', header: 'Level Variance', accessor: r => r.levelVariance, sortType: 'string', align: 'center', minWidth: 120 },
       {
@@ -268,27 +199,149 @@ export default function PoisonView() {
         ),
       },
     ];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rows, poisonTypeLabelById]); // allows closing form on self-delete
+  }, [rows, poisonTypeById]);
 
   // ----- Search -----
   const globalFilter = (p: Poison, q: string) => {
     const s = q.toLowerCase();
-    return [p.id, p.name, poisonTypeLabelById.get(p.type) ?? p.type, p.level, p.levelVariance]
+    return [p.id, p.name, poisonTypeById.get(p.type) ?? p.type, p.level, p.levelVariance]
       .some(v => String(v ?? '').toLowerCase().includes(s));
   };
 
-  // Prepare select options for Poison Types (for the LabeledSelect in the form), memoized for performance
-  const poisonTypeOptions = useMemo(
-    () =>
-      poisonTypes.map((pt) => ({
-        value: pt.id,                         // what we store in Poison.type
-        label: `${pt.type}`,                  // what users see
-      })),
-    [poisonTypes]
-  );
+  /* ------------------------------------------------------------------ */
+  /* Actions                                                            */
+  /* ------------------------------------------------------------------ */
 
-  // ----- Render -----
+  const startNew = () => {
+    setViewing(false);
+    setEditingId(null);
+    setForm(emptyVM());
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startView = (row: Poison) => {
+    setViewing(true);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startEdit = (row: Poison) => {
+    setViewing(false);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startDuplicate = (row: Poison) => {
+    setViewing(false);
+    setEditingId(null);
+    const vm = toVM(row);
+    vm.id = prefix;
+    vm.name += ' (Copy)';
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const cancelForm = () => {
+    setViewing(false);
+    setEditingId(null);
+    setErrors({});
+    setShowForm(false);
+  };
+
+  const saveForm = async () => {
+
+    if (submitting) return;
+
+    const nextErrors = computeErrors(form);
+    setErrors(nextErrors);
+    if (Object.values(nextErrors).some(Boolean)) {
+      return;
+    }
+
+    setSubmitting(true);
+
+    const payload = fromVM(form);
+    const isEditing = Boolean(editingId);
+
+    try {
+      const opts = isEditing
+        ? { method: 'PUT' as const, useResourceIdPath: true }
+        : { method: 'POST' as const, useResourceIdPath: false };
+
+      await upsertPoison(payload, opts);
+
+      setRows((prev) => {
+        if (isEditing) {
+          const idx = prev.findIndex((r) => r.id === payload.id);
+          if (idx >= 0) {
+            const copy = [...prev];
+            copy[idx] = { ...copy[idx], ...payload };
+            return copy;
+          }
+          return [payload, ...prev];
+        }
+        return [payload, ...prev];
+      });
+
+      setShowForm(false);
+      setViewing(false);
+      setEditingId(null);
+
+      toast({
+        variant: 'success',
+        title: isEditing ? 'Updated' : 'Saved',
+        description: `Poison "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
+      });
+    } catch (err) {
+      toast({
+        variant: 'danger',
+        title: 'Save failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onDelete = async (row: Poison) => {
+
+    if (submitting) return;
+    setSubmitting(true);
+
+    const ok = await confirm({
+      title: 'Delete Poison',
+      body: `Delete "${row.id}"? This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    const prev = rows;
+    setRows(prev.filter((r) => r.id !== row.id));
+
+    try {
+      await deletePoison(row.id);
+      if (editingId === row.id || viewing) cancelForm();
+      toast({ variant: 'success', title: 'Deleted', description: `Poison "${row.id}" deleted.` });
+    } catch (err) {
+      setRows(prev);
+      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err), });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  /* ------------------------------------------------------------------ */
+  /* Render                                                             */
+  /* ------------------------------------------------------------------ */
+
   if (loading) return <div>Loading…</div>;
   if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
 
@@ -296,9 +349,9 @@ export default function PoisonView() {
     <>
       <h2>Poisons</h2>
 
-      {/* Toolbar shown only when table visible */}
+      {/* Toolbar hidden while form visible */}
       {!showForm && (
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '12px 0' }}>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
           <button onClick={startNew}>New Poison</button>
           <DataTableSearchInput
             value={query}
@@ -306,57 +359,74 @@ export default function PoisonView() {
             placeholder="Search poisons…"
             aria-label="Search poisons"
           />
+
           {/* Reset and auto-fit column widths */}
           <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
           <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 
-      {/* Form panel (Create & Edit) */}
+      {/* Display main Form */}
       {showForm && (
-        <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`} style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}>
-          <h3 style={{ marginTop: 0 }}>
-            {viewing ? 'View Poison' : (editingId ? 'Edit Poison' : 'New Poison')}
-          </h3>
+        <div className="form-container">
+          {/* Simple overlay while submitting */}
+          {submitting && (<div className="overlay"><Spinner size={24} /> <span>Saving…</span> </div>)}
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-            <LabeledInput label="ID" value={form.id} onChange={makeIDOnChange<typeof form>('id', setForm, prefix)} disabled={!!editingId || viewing} error={errors.id} />
-            <LabeledInput label="Name" value={form.name} onChange={(v) => setForm((s) => ({ ...s, name: v }))} error={errors.name} disabled={viewing} />
+          <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`}>
+            <h3>{viewing ? 'View' : editingId ? 'Edit' : 'New'} Poison</h3>
 
-            <LabeledSelect
-              label="Type"
-              value={form.type}
-              onChange={(v) => setForm(s => ({ ...s, type: v }))}
-              options={poisonTypeOptions}
-              disabled={typesLoading || viewing}
-              error={viewing ? undefined : errors.type}
-              helperText={typesLoading ? 'Loading Poison Types…' : undefined}
-            />
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+              <LabeledInput label="ID" value={form.id} onChange={makeIDOnChange<typeof form>('id', setForm, prefix)} disabled={!!editingId || viewing} error={errors.id} />
+              <LabeledInput label="Name" value={form.name} onChange={(v) => setForm((s) => ({ ...s, name: v }))} error={errors.name} disabled={viewing} />
 
-            <LabeledInput label="Level" type="number" value={String(form.level).trim()} disabled={viewing}
-              onChange={makeUnsignedIntOnChange<typeof form>('level', setForm)}
-              inputProps={{ inputMode: 'numeric', pattern: '\\d*', }} // mobile numeric keypad
-              error={errors.level}
-            />
+              <LabeledSelect
+                label="Type"
+                value={form.type}
+                onChange={(v) => setForm(s => ({ ...s, type: v }))}
+                options={poisonTypeOptions}
+                disabled={loading || viewing}
+                error={viewing ? undefined : errors.type}
+                helperText={loading ? 'Loading Poison Types…' : undefined}
+              />
 
-            <LabeledInput label="Level Variance" value={form.levelVariance} onChange={(v) => setForm((s) => ({ ...s, levelVariance: v }))} error={errors.variance} disabled={viewing} />
-          </div>
+              <LabeledInput label="Level" value={String(form.level).trim()} disabled={viewing}
+                onChange={makeUnsignedIntOnChange<typeof form>('level', setForm)}
+                inputProps={{ inputMode: 'numeric', pattern: '\\d*', }} // mobile numeric keypad
+                error={errors.level}
+              />
 
-          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
-            {!viewing && <button onClick={saveForm} disabled={hasErrors}>Save</button>}
-            <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
+              <LabeledInput label="Level Variance" value={form.levelVariance} onChange={(v) => setForm((s) => ({ ...s, levelVariance: v }))} error={errors.variance} disabled={viewing} />
+            </div>
+
+            {/* Action buttons */}
+            <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+              {!viewing && <button onClick={saveForm} disabled={hasErrors || submitting}>{submitting ? 'Submitting…' : 'Save'}</button>}
+              <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
+            </div>
+
+            {/* Validation errors */}
+            {Object.values(errors).some(Boolean) && (
+              <div style={{ marginTop: 12, color: '#b00020' }}>
+                <h4 style={{ margin: '0 0 4px' }}>Please fix the following errors:</h4>
+                <ul style={{ margin: 0, paddingLeft: 20 }}>
+                  {Object.entries(errors).map(([field, error]) =>
+                    error ? <li key={field}>{error}</li> : null
+                  )}
+                </ul>
+              </div>
+            )}
           </div>
         </div>
       )}
 
       {/* Shared DataTable */}
       {!showForm && (
-        <DataTable<Poison>
+        <DataTable
           ref={dtRef}
           rows={rows}
           columns={columns}
           rowId={(r) => r.id}
-          initialSort={{ colId: 'name', dir: 'asc' }}
+          initialSort={{ colId: 'name', dir: 'asc' }} //
           // search
           searchQuery={query}
           globalFilter={globalFilter}
@@ -366,12 +436,8 @@ export default function PoisonView() {
           pageSize={pageSize}
           onPageChange={setPage}
           onPageSizeChange={setPageSize}
-          pageSizeOptions={[5, 10, 20, 50]}
           // styles
-          tableMinWidth={0} // Allow table to shrink below container width (enables horizontal scroll when needed)
-          zebra
-          // Resizable columns
-          resizable
+          tableMinWidth={0} // allow table to shrink below container width (for better mobile support)
           persistKey="dt.poisons.v1"
           ariaLabel='Poisons data'
         />


### PR DESCRIPTION
This pull request significantly refactors and improves the `PoisonView` component, focusing on code organization, form usability, validation, and user experience. The changes introduce a clear view model for form state, consolidate data loading, improve validation feedback, and enhance UI responsiveness during async operations.

**Key improvements include:**

### Code Structure & State Management

- Introduced a dedicated view model (`FormState`) and conversion helpers (`toVM`, `fromVM`, `emptyVM`) to separate form state from the backend `Poison` type, making form handling more robust and maintainable. (`[src/endpoints/poison/PoisonView.tsxL27-R84](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L27-R84)`)
- Consolidated all data loading (poisons and poison types) into a single `useEffect`, simplifying the data-fetching logic and error handling. (`[src/endpoints/poison/PoisonView.tsxL47-R295](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`)

### Validation & Error Handling

- Refactored form validation into a reusable `computeErrors` function, providing immediate, field-specific error feedback and a summary of validation errors below the form. (`[[1]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`, `[[2]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919R401-R429)`)
- Improved error display by listing all current validation errors in the UI, making it easier for users to correct mistakes. (`[src/endpoints/poison/PoisonView.tsxR401-R429](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919R401-R429)`)

### User Experience & UI

- Added a `submitting` state and an overlay spinner to indicate when form actions (save/delete) are in progress, preventing duplicate submissions and improving perceived responsiveness. (`[[1]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`, `[[2]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919R307-R376)`)
- Enhanced the form and table UI: disabled inputs/buttons appropriately, improved toolbar visibility logic, and made the table more mobile-friendly by allowing it to shrink below container width. (`[[1]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L331-R392)`, `[[2]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L369-R440)`)

### Table & Actions

- Refactored table columns and search logic to use the new view model and poison type mapping, ensuring the display of human-friendly poison type names and consistent filtering. (`[src/endpoints/poison/PoisonView.tsxL47-R295](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`)
- Improved action handlers (`startNew`, `startEdit`, `startDuplicate`, `startView`, `onDelete`) to use the new form state and validation logic, reducing bugs and code duplication. (`[[1]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`, `[[2]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919R307-R376)`)

### Minor Improvements

- Cleaned up unused code and comments, and improved naming consistency throughout the component. (`[src/endpoints/poison/PoisonView.tsxL47-R295](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`)

These changes collectively make the `PoisonView` component more maintainable, user-friendly, and robust.

---

**References:**  
- Code structure & state management: (`[[1]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L27-R84)`, `[[2]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`)  
- Validation & error handling: (`[[1]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`, `[[2]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919R401-R429)`)  
- User experience & UI: (`[[1]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`, `[[2]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919R307-R376)`, `[[3]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L331-R392)`, `[[4]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L369-R440)`)  
- Table & actions: (`[[1]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`, `[[2]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919R307-R376)`)  
- Minor improvements: (`[src/endpoints/poison/PoisonView.tsxL47-R295](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L47-R295)`)