### PR TITLE
Update Profession with latest features

### DIFF
--- a/src/components/inputs/IdCostListEditor.tsx
+++ b/src/components/inputs/IdCostListEditor.tsx
@@ -116,8 +116,8 @@ export function IdCostListEditor({
           gap: 8,
         }}
       >
-        <div style={{ fontWeight: 600 }}>{categoryColumnLabel}</div>
-        <div style={{ fontWeight: 600 }}>{costColumnLabel}</div>
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{categoryColumnLabel}</div>}
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{costColumnLabel}</div>}
         {showActions && <div />}
 
         {rows.map((row, i) => (

--- a/src/components/inputs/IdTypeListEditor.tsx
+++ b/src/components/inputs/IdTypeListEditor.tsx
@@ -150,8 +150,8 @@ export function IdTypeListEditor<
           gap: 8,
         }}
       >
-        <div style={{ fontWeight: 600 }}>{idColumnLabel}</div>
-        <div style={{ fontWeight: 600 }}>{typeColumnLabel}</div>
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{idColumnLabel}</div>}
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{typeColumnLabel}</div>}
         {showActions && <div />}
 
         {rows.map((row, i) => (

--- a/src/components/inputs/SkillTypeListEditor.tsx
+++ b/src/components/inputs/SkillTypeListEditor.tsx
@@ -144,9 +144,9 @@ export function SkillTypeListEditor<TType extends string = string>({
           gap: 8,
         }}
       >
-        <div style={{ fontWeight: 600 }}>{idColumnLabel}</div>
-        <div style={{ fontWeight: 600 }}>{subcategoryColumnLabel}</div>
-        <div style={{ fontWeight: 600 }}>{typeColumnLabel}</div>
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{idColumnLabel}</div>}
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{subcategoryColumnLabel}</div>}
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{typeColumnLabel}</div>}
         {showActions && <div />}
 
         {rows.map((row, i) => (

--- a/src/endpoints/profession/ProfessionView.tsx
+++ b/src/endpoints/profession/ProfessionView.tsx
@@ -7,6 +7,7 @@ import {
   fetchSkillcategories,
   fetchSkillgroups,
   fetchSpelllists,
+  deleteTrainingPackage,
 } from '../../api';
 
 import {
@@ -21,6 +22,7 @@ import {
   MarkupPreview,
   SkillTypeListEditor,
   SkillValueListEditor,
+  Spinner,
   useConfirm, useToast,
 } from '../../components';
 
@@ -61,7 +63,10 @@ import {
 
 const prefix = 'PROFESSION_';
 
-// ---------- VM row types ----------
+/* ------------------------------------------------------------------ */
+/* VM types                                                           */
+/* ------------------------------------------------------------------ */
+
 type SpellListChoiceVM = { numChoices: string; options: string[] };
 type SkillBonusVM = { id: string; subcategory?: string | undefined; value: string };
 type IdValueVM = { id: string; value: string };
@@ -101,6 +106,29 @@ type FormState = {
   skillGroupSkillDevelopmentTypeChoices: IdChoiceVM[];
 
   skillCategoryCosts: CategoryCostVM[];
+};
+
+type FormErrors = {
+  id?: string;
+  name?: string;
+  book?: string;
+  spellUserType?: string;
+  realms?: string;
+  stats?: string;
+  baseSpellListChoices?: string;
+  skillBonuses?: string;
+  skillCategoryProfessionBonuses?: string;
+  skillCategorySpecialBonuses?: string;
+  skillGroupProfessionBonuses?: string;
+  skillGroupSpecialBonuses?: string;
+  skillDevelopmentTypes?: string;
+  skillCategorySkillDevelopmentTypes?: string;
+  skillGroupSkillDevelopmentTypes?: string;
+  skillSubcategoryDevelopmentTypeChoices?: string;
+  skillDevelopmentTypeChoices?: string;
+  skillCategorySkillDevelopmentTypeChoices?: string;
+  skillGroupSkillDevelopmentTypeChoices?: string;
+  skillCategoryCosts?: string;
 };
 
 const emptyVM = (): FormState => ({
@@ -276,9 +304,9 @@ const fromVM = (vm: FormState): Profession => ({
   })),
 });
 
-// ---------- validators / sanitizers ----------
-// 1–3 colon-separated positive numbers, e.g. "11", "3:3:3", "10:10"
-const COST_RE = /^[1-9]\d*(?::[1-9]\d*){0,2}$/;
+/* ------------------------------------------------------------------ */
+/* View                                                               */
+/* ------------------------------------------------------------------ */
 
 export default function ProfessionView() {
   const dtRef = useRef<DataTableHandle>(null);
@@ -286,6 +314,8 @@ export default function ProfessionView() {
   const [rows, setRows] = useState<Profession[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const hasErrors = Object.values(errors).some(Boolean);
 
   // reference lists
   const [books, setBooks] = useState<Book[]>([]);
@@ -294,12 +324,6 @@ export default function ProfessionView() {
   const [categories, setCategories] = useState<SkillCategory[]>([]);
   const [groups, setGroups] = useState<SkillGroup[]>([]);
 
-  const [booksLoading, setBooksLoading] = useState(true);
-  const [spellListsLoading, setSpellListsLoading] = useState(true);
-  const [skillsLoading, setSkillsLoading] = useState(true);
-  const [categoriesLoading, setCategoriesLoading] = useState(true);
-  const [groupsLoading, setGroupsLoading] = useState(true);
-
   const [query, setQuery] = useState('');
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
@@ -307,101 +331,47 @@ export default function ProfessionView() {
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [viewing, setViewing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [form, setForm] = useState<FormState>(emptyVM());
-
-  const [errors, setErrors] = useState<{
-    id?: string | undefined;
-    name?: string | undefined;
-    book?: string | undefined;
-    spellUserType?: string | undefined;
-    realms?: string | undefined;
-    stats?: string | undefined;
-    baseSpellListChoices?: string | undefined;
-    skillBonuses?: string | undefined;
-    skillCategoryProfessionBonuses?: string | undefined;
-    skillCategorySpecialBonuses?: string | undefined;
-    skillGroupProfessionBonuses?: string | undefined;
-    skillGroupSpecialBonuses?: string | undefined;
-    skillDevelopmentTypes?: string | undefined;
-    skillCategorySkillDevelopmentTypes?: string | undefined;
-    skillGroupSkillDevelopmentTypes?: string | undefined;
-    skillSubcategoryDevelopmentTypeChoices?: string | undefined;
-    skillDevelopmentTypeChoices?: string | undefined;
-    skillCategorySkillDevelopmentTypeChoices?: string | undefined;
-    skillGroupSkillDevelopmentTypeChoices?: string | undefined;
-    skillCategoryCosts?: string | undefined;
-  }>({});
 
   const [previewDescription, setPreviewDescription] = useState(false);
 
   const toast = useToast();
   const confirm = useConfirm();
 
-  // ---------- load main list ----------
+  /* ------------------------------------------------------------------ */
+  /* Load data                                                          */
+  /* ------------------------------------------------------------------ */
+
   useEffect(() => {
-    let mounted = true;
     (async () => {
       try {
-        const list = await fetchProfessions();
-        if (!mounted) return;
-        setRows(list);
+        const [p, b, s, c, g, sl] = await Promise.all([
+          fetchProfessions(),
+          fetchBooks(),
+          fetchSkills(),
+          fetchSkillcategories(),
+          fetchSkillgroups(),
+          fetchSpelllists(),
+        ]);
+        setRows(p);
+        setBooks(b);
+        setSkills(s);
+        setCategories(c);
+        setGroups(g);
+        setSpellLists(sl);
       } catch (e) {
-        if (!mounted) return;
-        setError(e instanceof Error ? e.message : String(e));
+        setError(String(e));
       } finally {
-        if (mounted) setLoading(false);
+        setLoading(false);
       }
     })();
-    return () => { mounted = false; };
   }, []);
 
-  // ---------- load refs ----------
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try { const list = await fetchBooks(); if (mounted) setBooks(list); }
-      finally { if (mounted) setBooksLoading(false); }
-    })();
-    return () => { mounted = false; };
-  }, []);
+  /* ------------------------------------------------------------------ */
+  /* Helpers                                                            */
+  /* ------------------------------------------------------------------ */
 
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try { const list = await fetchSpelllists(); if (mounted) setSpellLists(list); }
-      finally { if (mounted) setSpellListsLoading(false); }
-    })();
-    return () => { mounted = false; };
-  }, []);
-
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try { const list = await fetchSkills(); if (mounted) setSkills(list); }
-      finally { if (mounted) setSkillsLoading(false); }
-    })();
-    return () => { mounted = false; };
-  }, []);
-
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try { const list = await fetchSkillcategories(); if (mounted) setCategories(list); }
-      finally { if (mounted) setCategoriesLoading(false); }
-    })();
-    return () => { mounted = false; };
-  }, []);
-
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try { const list = await fetchSkillgroups(); if (mounted) setGroups(list); }
-      finally { if (mounted) setGroupsLoading(false); }
-    })();
-    return () => { mounted = false; };
-  }, []);
-
-  // ---------- option maps ----------
   const bookNameById = useMemo(() => {
     const m = new Map<string, string>();
     for (const b of books) m.set(b.id, b.name);
@@ -452,8 +422,14 @@ export default function ProfessionView() {
     []
   );
 
-  // ---------- validation ----------
-  const computeErrors = (draft = form) => {
+  /* ------------------------------------------------------------------ */
+  /* Validation                                                         */
+  /* ------------------------------------------------------------------ */
+
+  // 1–3 colon-separated positive numbers, e.g. "11", "3:3:3", "10:10"
+  const COST_RE = /^[1-9]\d*(?::[1-9]\d*){0,2}$/;
+
+  const computeErrors = (draft: FormState): FormErrors => {
     const e: typeof errors = {};
 
     const id = draft.id.trim();
@@ -568,118 +544,14 @@ export default function ProfessionView() {
     return e;
   };
 
-  const hasErrors = Boolean(Object.values(errors).some(Boolean));
-
   useEffect(() => {
     if (!showForm || viewing) return;
-    setErrors(computeErrors());
+    setErrors(computeErrors(form));
   }, [form, showForm, viewing, rows]);
 
-  // ---------- actions ----------
-  const startNew = () => {
-    setViewing(false);
-    setEditingId(null);
-    setForm(emptyVM());
-    setErrors({});
-    setShowForm(true);
-  };
-  const startView = (row: Profession) => {
-    setViewing(true);
-    setEditingId(row.id);
-    setForm(toVM(row));
-    setErrors({});
-    setShowForm(true);
-  };
-  const startEdit = (row: Profession) => {
-    setViewing(false);
-    setEditingId(row.id);
-    setForm(toVM(row));
-    setErrors({});
-    setShowForm(true);
-  };
-  const startDuplicate = (row: Profession) => {
-    setViewing(false);
-    setEditingId(null);
-    const vm = toVM(row);
-    vm.id = prefix;
-    vm.name = vm.name ? `${vm.name} (Copy)` : vm.name;
-    setForm(vm);
-    setErrors({});
-    setShowForm(true);
-  };
-  const cancelForm = () => {
-    setShowForm(false);
-    setViewing(false);
-    setEditingId(null);
-    setErrors({});
-  };
-
-  const saveForm = async () => {
-    const nextErrors = computeErrors(form);
-    setErrors(nextErrors);
-    if (Object.values(nextErrors).some(Boolean)) return;
-
-    const payload = fromVM(form);
-    const isEditing = Boolean(editingId);
-    try {
-      const opts = isEditing
-        ? { method: 'PUT' as const, useResourceIdPath: true }
-        : { method: 'POST' as const, useResourceIdPath: false };
-      await upsertProfession(payload, opts);
-
-      setRows(prev => {
-        if (isEditing) {
-          const idx = prev.findIndex(r => r.id === payload.id);
-          if (idx >= 0) {
-            const copy = [...prev];
-            copy[idx] = { ...copy[idx], ...payload };
-            return copy;
-          }
-          return [payload, ...prev];
-        }
-        return [payload, ...prev];
-      });
-
-      setShowForm(false);
-      setViewing(false);
-      setEditingId(null);
-      toast({
-        variant: 'success',
-        title: isEditing ? 'Updated' : 'Saved',
-        description: `Profession "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
-      });
-    } catch (err) {
-      toast({
-        variant: 'danger',
-        title: 'Save failed',
-        description: String(err instanceof Error ? err.message : err),
-      });
-    }
-  };
-
-  const onDelete = async (row: Profession) => {
-    const ok = await confirm({
-      title: 'Delete Profession',
-      body: `Delete "${row.id}"? This cannot be undone.`,
-      confirmText: 'Delete',
-      cancelText: 'Cancel',
-      tone: 'danger',
-    });
-    if (!ok) return;
-
-    const prev = rows;
-    setRows(prev.filter(r => r.id !== row.id));
-    try {
-      await deleteProfession(row.id);
-      if (editingId === row.id || viewing) cancelForm();
-      toast({ variant: 'success', title: 'Deleted', description: `Profession "${row.id}" deleted.` });
-    } catch (err) {
-      setRows(prev);
-      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err) });
-    }
-  };
-
-  // ---------- table ----------
+  /* ------------------------------------------------------------------ */
+  /* Table                                                              */
+  /* ------------------------------------------------------------------ */
   const columns: ColumnDef<Profession>[] = useMemo(() => [
     { id: 'id', header: 'ID', accessor: r => r.id, sortType: 'string', minWidth: 260 },
     { id: 'name', header: 'Name', accessor: r => r.name, sortType: 'string', minWidth: 180 },
@@ -743,8 +615,135 @@ export default function ProfessionView() {
     ].some(v => String(v ?? '').toLowerCase().includes(s));
   };
 
-  if (loading) return <div>Loading…</div>;
-  if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
+  /* ------------------------------------------------------------------ */
+  /* Actions                                                            */
+  /* ------------------------------------------------------------------ */
+
+  const startNew = () => {
+    setViewing(false);
+    setEditingId(null);
+    setForm(emptyVM());
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startView = (row: Profession) => {
+    setViewing(true);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startEdit = (row: Profession) => {
+    setViewing(false);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startDuplicate = (row: Profession) => {
+    setViewing(false);
+    setEditingId(null);
+    const vm = toVM(row);
+    vm.id = prefix;
+    vm.name += ' (Copy)';
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const cancelForm = () => {
+    setViewing(false);
+    setEditingId(null);
+    setErrors({});
+    setShowForm(false);
+  };
+
+  const saveForm = async () => {
+
+    if (submitting) return;
+
+    const nextErrors = computeErrors(form);
+    setErrors(nextErrors);
+    if (Object.values(nextErrors).some(Boolean)) {
+      return;
+    }
+
+    setSubmitting(true);
+
+    const payload = fromVM(form);
+    const isEditing = Boolean(editingId);
+
+    try {
+      const opts = isEditing
+        ? { method: 'PUT' as const, useResourceIdPath: true }
+        : { method: 'POST' as const, useResourceIdPath: false };
+
+      await upsertProfession(payload, opts);
+
+      setRows((prev) => {
+        if (isEditing) {
+          const idx = prev.findIndex((r) => r.id === payload.id);
+          if (idx >= 0) {
+            const copy = [...prev];
+            copy[idx] = { ...copy[idx], ...payload };
+            return copy;
+          }
+          return [payload, ...prev];
+        }
+        return [payload, ...prev];
+      });
+
+      setShowForm(false);
+      setViewing(false);
+      setEditingId(null);
+
+      toast({
+        variant: 'success',
+        title: isEditing ? 'Updated' : 'Saved',
+        description: `Profession "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
+      });
+    } catch (err) {
+      toast({
+        variant: 'danger',
+        title: 'Save failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onDelete = async (row: Profession) => {
+
+    if (submitting) return;
+    setSubmitting(true);
+
+    const ok = await confirm({
+      title: 'Delete Profession',
+      body: `Delete "${row.id}"? This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    const prev = rows;
+    setRows(prev.filter((r) => r.id !== row.id));
+
+    try {
+      await deleteProfession(row.id);
+      if (editingId === row.id || viewing) cancelForm();
+      toast({ variant: 'success', title: 'Deleted', description: `Profession "${row.id}" deleted.` });
+    } catch (err) {
+      setRows(prev);
+      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err), });
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   // ---------- reusable updaters (guard + narrow + full-object writes) ----------
   const updateSpellListChoiceAt = (index: number, patch: Partial<SpellListChoiceVM>) => {
@@ -774,12 +773,20 @@ export default function ProfessionView() {
     });
   };
 
+  /* ------------------------------------------------------------------ */
+  /* Render                                                             */
+  /* ------------------------------------------------------------------ */
+
+  if (loading) return <div>Loading…</div>;
+  if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
+
   return (
     <>
       <h2>Professions</h2>
 
+      {/* Toolbar hidden while form visible */}
       {!showForm && (
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '12px 0' }}>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
           <button onClick={startNew}>New Profession</button>
           <DataTableSearchInput
             value={query}
@@ -787,420 +794,446 @@ export default function ProfessionView() {
             placeholder="Search professions…"
             aria-label="Search professions"
           />
+
+          {/* Reset and auto-fit column widths */}
           <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
           <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 
+      {/* Display main Form */}
       {showForm && (
-        <div
-          className={`form-panel ${viewing ? 'form-panel--view' : ''}`}
-          style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}
-        >
-          <h3 style={{ marginTop: 0 }}>
-            {viewing ? 'View Profession' : (editingId ? 'Edit Profession' : 'New Profession')}
-          </h3>
+        <div className="form-container">
+          {/* Simple overlay while submitting */}
+          {submitting && (<div className="overlay"><Spinner size={24} /> <span>Saving…</span> </div>)}
 
-          {/* Basic fields */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 8 }}>
-            <LabeledInput
-              label="ID"
-              value={form.id}
-              onChange={makeIDOnChange<typeof form>('id', setForm, prefix)}
-              disabled={!!editingId || viewing}
-              error={viewing ? undefined : errors.id}
-            />
-            <LabeledInput
-              label="Name"
-              value={form.name}
-              onChange={(v) => setForm((s) => ({ ...s, name: v }))}
-              disabled={viewing}
-              error={viewing ? undefined : errors.name}
-            />
+          <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`}>
+            <h3>{viewing ? 'View' : editingId ? 'Edit' : 'New'} Profession</h3>
 
-            <LabeledSelect
-              label="Book"
-              value={form.book}
-              onChange={(v) => setForm((s) => ({ ...s, book: v }))}
-              options={bookOptions}
-              disabled={booksLoading || viewing}
-              error={viewing ? undefined : errors.book}
-            />
-
-            <LabeledSelect
-              label="Spell User Type"
-              value={form.spellUserType}
-              onChange={(v) => setForm((s) => ({ ...s, spellUserType: v as SpellUserType }))}
-              options={spellUserTypeOptions}
-              disabled={viewing}
-              error={viewing ? undefined : errors.spellUserType}
-            />
-          </div>
-
-          {/* Description with preview */}
-          <section style={{ marginTop: 8 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <h4 style={{ margin: '8px 0' }}>Description</h4>
-              <button type="button" onClick={() => setPreviewDescription((p) => !p)}>
-                {previewDescription ? 'Edit' : 'Preview'}
-              </button>
-            </div>
-            {previewDescription ? (
-              <MarkupPreview
-                content={form.description}
-                emptyHint="No description"
-                className="preview-html"
-                style={{ border: '1px solid var(--border)', borderRadius: 6, padding: 8 }}
+            {/* Basic fields */}
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 8 }}>
+              <LabeledInput
+                label="ID"
+                value={form.id}
+                onChange={makeIDOnChange<typeof form>('id', setForm, prefix)}
+                disabled={!!editingId || viewing}
+                error={viewing ? undefined : errors.id}
               />
-            ) : (
-              <label style={{ display: 'grid', gap: 6 }}>
-                <textarea
-                  value={form.description}
-                  onChange={(e) => setForm((s) => ({ ...s, description: e.target.value }))}
-                  disabled={viewing}
-                  rows={4}
-                />
-              </label>
-            )}
-          </section>
+              <LabeledInput
+                label="Name"
+                value={form.name}
+                onChange={(v) => setForm((s) => ({ ...s, name: v }))}
+                disabled={viewing}
+                error={viewing ? undefined : errors.name}
+              />
 
-          {/* Realms / Stats */}
-          <section style={{ marginTop: 12 }}>
-            <h4 style={{ margin: '8px 0' }}>Realms</h4>
-            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-              {realmOptions.map((opt) => (
-                <CheckboxInput
-                  key={opt.value}
-                  label={opt.label}
-                  checked={form.realms.includes(opt.value as Realm)}
-                  onChange={() => toggleStringInArray('realms', opt.value)}
-                  disabled={viewing}
-                />
-              ))}
+              <LabeledSelect
+                label="Book"
+                value={form.book}
+                onChange={(v) => setForm((s) => ({ ...s, book: v }))}
+                options={bookOptions}
+                disabled={loading || viewing}
+                error={viewing ? undefined : errors.book}
+              />
+
+              <LabeledSelect
+                label="Spell User Type"
+                value={form.spellUserType}
+                onChange={(v) => setForm((s) => ({ ...s, spellUserType: v as SpellUserType }))}
+                options={spellUserTypeOptions}
+                disabled={viewing}
+                error={viewing ? undefined : errors.spellUserType}
+              />
             </div>
-            {errors.realms && <div style={{ color: '#b00020', marginTop: 6 }}>{errors.realms}</div>}
 
-            <h4 style={{ margin: '16px 0 8px' }}>Stats</h4>
-            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-              {statOptions.map((opt) => (
-                <CheckboxInput
-                  key={opt.value}
-                  label={opt.label}
-                  checked={form.stats.includes(opt.value as Stat)}
-                  onChange={() => toggleStringInArray('stats', opt.value)}
-                  disabled={viewing}
+            {/* Description with preview */}
+            <section style={{ marginTop: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <h4 style={{ margin: '8px 0' }}>Description</h4>
+                <button type="button" onClick={() => setPreviewDescription((p) => !p)}>
+                  {previewDescription ? 'Edit' : 'Preview'}
+                </button>
+              </div>
+              {previewDescription ? (
+                <MarkupPreview
+                  content={form.description}
+                  emptyHint="No description"
+                  className="preview-html"
+                  style={{ border: '1px solid var(--border)', borderRadius: 6, padding: 8 }}
                 />
-              ))}
-            </div>
-            {errors.stats && <div style={{ color: '#b00020', marginTop: 6 }}>{errors.stats}</div>}
-          </section>
-
-          {/* Base Spell List Choices */}
-          <section style={{ marginTop: 12 }}>
-            <h4 style={{ margin: '8px 0' }}>Base Spell List Choices</h4>
-            {!viewing && (
-              <button
-                type="button"
-                onClick={() => setForm((s) => ({
-                  ...s,
-                  baseSpellListChoices: [...s.baseSpellListChoices, { numChoices: '', options: [] }],
-                }))}
-                style={{ marginBottom: 8 }}
-              >
-                + Add spell list choice row
-              </button>
-            )}
-            <div style={{ display: 'grid', gridTemplateColumns: '140px 1fr', gap: 8 }}>
-              <div style={{ fontWeight: 600 }}>Num Choices</div>
-              <div style={{ fontWeight: 600 }}>Options (Spell Lists)</div>
-              {form.baseSpellListChoices.map((row, i) => (
-                <React.Fragment key={`bsl-${i}`}>
-                  <LabeledInput
-                    label="Num Choices"
-                    hideLabel
-                    ariaLabel="Num choices"
-                    value={row.numChoices}
-                    onChange={(v) => updateSpellListChoiceAt(i, { numChoices: sanitizeUnsignedInt(v) })}
+              ) : (
+                <label style={{ display: 'grid', gap: 6 }}>
+                  <textarea
+                    value={form.description}
+                    onChange={(e) => setForm((s) => ({ ...s, description: e.target.value }))}
                     disabled={viewing}
-                    width={120}
+                    rows={4}
                   />
-                  <div style={{ display: 'grid', gap: 8 }}>
-                    {!viewing && (
-                      <button
-                        type="button"
-                        onClick={() => updateSpellListChoiceAt(i, { options: [...row.options, ''] })}
-                      >
-                        + Add spell list option
-                      </button>
-                    )}
-                    {row.options.map((opt, oi) => (
-                      <div key={`bsl-${i}-opt-${oi}`} style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 8 }}>
-                        <LabeledSelect
-                          label="Spell List"
-                          hideLabel
-                          value={opt}
-                          onChange={(v) => {
-                            const nextOpts = row.options.slice();
-                            if (oi < 0 || oi >= nextOpts.length) return;
-                            nextOpts[oi] = v;
-                            updateSpellListChoiceAt(i, { options: nextOpts });
-                          }}
-                          options={spellListOptions}
-                          disabled={spellListsLoading || viewing}
-                        />
-                        {!viewing && (
-                          <button
-                            type="button"
-                            onClick={() => {
+                </label>
+              )}
+            </section>
+
+            {/* Realms / Stats */}
+            <section style={{ marginTop: 12 }}>
+              <h4 style={{ margin: '8px 0' }}>Realms</h4>
+              <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+                {realmOptions.map((opt) => (
+                  <CheckboxInput
+                    key={opt.value}
+                    label={opt.label}
+                    checked={form.realms.includes(opt.value as Realm)}
+                    onChange={() => toggleStringInArray('realms', opt.value)}
+                    disabled={viewing}
+                  />
+                ))}
+              </div>
+              {errors.realms && <div style={{ color: '#b00020', marginTop: 6 }}>{errors.realms}</div>}
+
+              <h4 style={{ margin: '16px 0 8px' }}>Stats</h4>
+              <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+                {statOptions.map((opt) => (
+                  <CheckboxInput
+                    key={opt.value}
+                    label={opt.label}
+                    checked={form.stats.includes(opt.value as Stat)}
+                    onChange={() => toggleStringInArray('stats', opt.value)}
+                    disabled={viewing}
+                  />
+                ))}
+              </div>
+              {errors.stats && <div style={{ color: '#b00020', marginTop: 6 }}>{errors.stats}</div>}
+            </section>
+
+            {/* Base Spell List Choices */}
+            <section style={{ marginTop: 12 }}>
+              <h4 style={{ margin: '8px 0' }}>Base Spell List Choices</h4>
+              {!viewing && (
+                <button
+                  type="button"
+                  onClick={() => setForm((s) => ({
+                    ...s,
+                    baseSpellListChoices: [...s.baseSpellListChoices, { numChoices: '', options: [] }],
+                  }))}
+                  style={{ marginBottom: 8 }}
+                >
+                  + Add spell list choice row
+                </button>
+              )}
+              <div style={{ display: 'grid', gridTemplateColumns: '140px 1fr', gap: 8 }}>
+                {form.baseSpellListChoices.length > 0 && <div style={{ fontWeight: 600 }}>Num Choices</div>}
+                {form.baseSpellListChoices.length > 0 && <div style={{ fontWeight: 600 }}>Options (Spell Lists)</div>}
+                {form.baseSpellListChoices.map((row, i) => (
+                  <React.Fragment key={`bsl-${i}`}>
+                    <LabeledInput
+                      label="Num Choices"
+                      hideLabel
+                      ariaLabel="Num choices"
+                      value={row.numChoices}
+                      onChange={(v) => updateSpellListChoiceAt(i, { numChoices: sanitizeUnsignedInt(v) })}
+                      disabled={viewing}
+                      width={120}
+                    />
+                    <div style={{ display: 'grid', gap: 8 }}>
+                      {!viewing && (
+                        <button
+                          type="button"
+                          onClick={() => updateSpellListChoiceAt(i, { options: [...row.options, ''] })}
+                        >
+                          + Add spell list option
+                        </button>
+                      )}
+                      {row.options.map((opt, oi) => (
+                        <div key={`bsl-${i}-opt-${oi}`} style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 8 }}>
+                          <LabeledSelect
+                            label="Spell List"
+                            hideLabel
+                            value={opt}
+                            onChange={(v) => {
                               const nextOpts = row.options.slice();
                               if (oi < 0 || oi >= nextOpts.length) return;
-                              nextOpts.splice(oi, 1);
+                              nextOpts[oi] = v;
                               updateSpellListChoiceAt(i, { options: nextOpts });
                             }}
-                            style={{ color: '#b00020' }}
-                          >
-                            Remove
-                          </button>
-                        )}
-                      </div>
-                    ))}
-                    {!viewing && (
-                      <button
-                        type="button"
-                        onClick={() => setForm((s) => {
-                          const copy = s.baseSpellListChoices.slice();
-                          if (i < 0 || i >= copy.length) return s;
-                          copy.splice(i, 1);
-                          return { ...s, baseSpellListChoices: copy };
-                        })}
-                        style={{ color: '#b00020' }}
-                      >
-                        Remove row
-                      </button>
-                    )}
-                  </div>
-                </React.Fragment>
-              ))}
+                            options={spellListOptions}
+                            disabled={loading || viewing}
+                          />
+                          {!viewing && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                const nextOpts = row.options.slice();
+                                if (oi < 0 || oi >= nextOpts.length) return;
+                                nextOpts.splice(oi, 1);
+                                updateSpellListChoiceAt(i, { options: nextOpts });
+                              }}
+                              style={{ color: '#b00020' }}
+                            >
+                              Remove
+                            </button>
+                          )}
+                        </div>
+                      ))}
+                      {!viewing && (
+                        <button
+                          type="button"
+                          onClick={() => setForm((s) => {
+                            const copy = s.baseSpellListChoices.slice();
+                            if (i < 0 || i >= copy.length) return s;
+                            copy.splice(i, 1);
+                            return { ...s, baseSpellListChoices: copy };
+                          })}
+                          style={{ color: '#b00020' }}
+                        >
+                          Remove row
+                        </button>
+                      )}
+                    </div>
+                  </React.Fragment>
+                ))}
+              </div>
+              {errors.baseSpellListChoices && <div style={{ color: '#b00020', marginTop: 6 }}>{errors.baseSpellListChoices}</div>}
+            </section>
+
+            {/* Skill Bonuses */}
+            <SkillValueListEditor
+              title="Skill Bonuses"
+              addButtonLabel='+ Add skill bonus'
+              rows={form.skillBonuses}
+              onChangeRows={(next) => setForm((s) => ({ ...s, skillBonuses: next }))}
+              idOptions={skillOptions}
+              loading={loading}
+              viewing={viewing}
+              error={errors.skillBonuses}
+              signedValues
+            />
+
+            {/* Category/Group bonus sections */}
+            <IdValueListEditor
+              title="Skill Category Profession Bonuses"
+              addButtonLabel='+ Add category profession bonus'
+              rows={form.skillCategoryProfessionBonuses}
+              onChangeRows={(next) => setForm((s) => ({ ...s, skillCategoryProfessionBonuses: next }))}
+              options={categoryOptions}
+              loading={loading}
+              viewing={viewing}
+              error={errors.skillCategoryProfessionBonuses}
+              signedValues
+            />
+
+            <IdValueListEditor
+              title="Skill Category Special Bonuses"
+              addButtonLabel='+ Add category special bonus'
+              rows={form.skillCategorySpecialBonuses}
+              onChangeRows={(next) => setForm((s) => ({ ...s, skillCategorySpecialBonuses: next }))}
+              options={categoryOptions}
+              loading={loading}
+              viewing={viewing}
+              error={errors.skillCategorySpecialBonuses}
+              signedValues
+            />
+
+            <IdValueListEditor
+              title="Skill Group Profession Bonuses"
+              addButtonLabel='+ Add group profession bonus'
+              rows={form.skillGroupProfessionBonuses}
+              onChangeRows={(next) => setForm((s) => ({ ...s, skillGroupProfessionBonuses: next }))}
+              options={groupOptions}
+              loading={loading}
+              viewing={viewing}
+              error={errors.skillGroupProfessionBonuses}
+              signedValues
+            />
+
+            <IdValueListEditor
+              title="Skill Group Special Bonuses"
+              addButtonLabel='+ Add group special bonus'
+              rows={form.skillGroupSpecialBonuses}
+              onChangeRows={(next) => setForm((s) => ({ ...s, skillGroupSpecialBonuses: next }))}
+              options={groupOptions}
+              loading={loading}
+              viewing={viewing}
+              error={errors.skillGroupSpecialBonuses}
+              signedValues
+            />
+
+            {/* Skill Development Types */}
+            <SkillTypeListEditor<SkillDevelopmentType>
+              title="Skill Development Types"
+              addButtonLabel='+ Add skill development type'
+              rows={form.skillDevelopmentTypes}
+              onChangeRows={(next) =>
+                setForm((s) => ({ ...s, skillDevelopmentTypes: next }))
+              }
+              idOptions={skillOptions}
+              typeOptions={developmentTypeOptions}
+              loading={loading}
+              viewing={viewing}
+              error={errors.skillDevelopmentTypes}
+            />
+
+            {/* Category / Group Skill Development Types */}
+            <IdTypeListEditor<string, SkillDevelopmentType>
+              title="Skill Category Skill Development Types"
+              addButtonLabel='+ Add category skill development type'
+              rows={form.skillCategorySkillDevelopmentTypes}
+              onChangeRows={(next) =>
+                setForm((s) => ({ ...s, skillCategorySkillDevelopmentTypes: next }))
+              }
+              idOptions={categoryOptions}
+              typeOptions={developmentTypeOptions}
+              loading={loading}
+              viewing={viewing}
+              error={errors.skillCategorySkillDevelopmentTypes}
+            />
+
+            <IdTypeListEditor<string, SkillDevelopmentType>
+              title="Skill Group Skill Development Types"
+              addButtonLabel='+ Add group skill development type'
+              rows={form.skillGroupSkillDevelopmentTypes}
+              onChangeRows={(next) =>
+                setForm((s) => ({ ...s, skillGroupSkillDevelopmentTypes: next }))
+              }
+              idOptions={groupOptions}
+              typeOptions={developmentTypeOptions}
+              loading={loading}
+              viewing={viewing}
+              error={errors.skillGroupSkillDevelopmentTypes}
+            />
+
+            {/* Skill Subcategory Development Type Choices */}
+            <ChoiceListEditor<SkillDevelopmentType, string>
+              title="Skill Subcategory Development Type Choices"
+              addRowButtonLabel='+ Add subcategory development type choice'
+              rows={form.skillSubcategoryDevelopmentTypeChoices}
+              onChangeRows={(next) =>
+                setForm((s) => ({ ...s, skillSubcategoryDevelopmentTypeChoices: next }))
+              }
+              typeOptions={developmentTypeOptions}
+              viewing={viewing}
+              error={errors.skillSubcategoryDevelopmentTypeChoices}
+              createEmptyOption={() => ''}
+              renderOptionEditor={({ option, setOption, removeOption, viewing }) => (
+                <div style={{ display: 'grid', gridTemplateColumns: viewing ? 'minmax(280px, 1fr) 1fr' : 'minmax(280px, 1fr) 1fr auto', gap: 8, }} >
+                  <LabeledSelect label="Skill" hideLabel ariaLabel="Skill" value={option} onChange={(v) => setOption(v)} options={skillOptions} disabled={loading || viewing} />
+                  {!viewing && (<button type="button" onClick={removeOption} style={{ color: '#b00020' }}>Remove</button>)}
+                </div>
+              )}
+            />
+
+            {/* Skill Development Type Choices */}
+            <ChoiceListEditor<SkillDevelopmentType, { id: string; subcategory?: string | undefined }>
+              addRowButtonLabel='+ Add skill development type choice'
+              title="Skill Development Type Choices"
+              rows={form.skillDevelopmentTypeChoices}
+              onChangeRows={(next) =>
+                setForm((s) => ({ ...s, skillDevelopmentTypeChoices: next }))
+              }
+              typeOptions={developmentTypeOptions}
+              viewing={viewing}
+              error={errors.skillDevelopmentTypeChoices}
+              createEmptyOption={() => ({ id: '', subcategory: '' })}
+              renderOptionEditor={({ option, setOption, removeOption, viewing }) => (
+                <div style={{ display: 'grid', gridTemplateColumns: viewing ? 'minmax(280px, 1fr) 1fr' : 'minmax(280px, 1fr) 1fr auto', gap: 8, }} >
+                  <LabeledSelect label="Skill" hideLabel ariaLabel="Skill" value={option.id} onChange={(v) => setOption({ id: v, subcategory: option.subcategory, })} options={skillOptions} disabled={loading || viewing} />
+                  <LabeledInput label="Subcategory" hideLabel ariaLabel="Subcategory" value={option.subcategory ?? ''} onChange={(v) => setOption({ id: option.id, subcategory: v || undefined, })} disabled={viewing} />
+                  {!viewing && (<button type="button" onClick={removeOption} style={{ color: '#b00020' }}>Remove</button>)}
+                </div>
+              )}
+            />
+
+            {/* Category / Group choice sections */}
+            <ChoiceListEditor<SkillDevelopmentType, string>
+              title="Skill Category Skill Development Type Choices"
+              addRowButtonLabel='+ Add category skill development type choice'
+              rows={form.skillCategorySkillDevelopmentTypeChoices}
+              onChangeRows={(next) =>
+                setForm((s) => ({ ...s, skillCategorySkillDevelopmentTypeChoices: next }))
+              }
+              typeOptions={developmentTypeOptions}
+              viewing={viewing}
+              error={errors.skillCategorySkillDevelopmentTypeChoices}
+              createEmptyOption={() => ''}
+              renderOptionEditor={({ option, setOption, removeOption, viewing }) => (
+                <div style={{ display: 'grid', gridTemplateColumns: viewing ? '1fr' : '1fr auto', gap: 8 }}>
+                  <LabeledSelect label="Category" hideLabel ariaLabel="Category" value={option} onChange={(v) => setOption(v)} options={categoryOptions} disabled={loading || viewing} />
+                  {!viewing && (<button type="button" onClick={removeOption} style={{ color: '#b00020' }}>Remove</button>)}
+                </div>
+              )}
+            />
+
+            <ChoiceListEditor<SkillDevelopmentType, string>
+              title="Skill Group Skill Development Type Choices"
+              addRowButtonLabel='+ Add group skill development type choice'
+              rows={form.skillGroupSkillDevelopmentTypeChoices}
+              onChangeRows={(next) =>
+                setForm((s) => ({ ...s, skillGroupSkillDevelopmentTypeChoices: next }))
+              }
+              typeOptions={developmentTypeOptions}
+              viewing={viewing}
+              error={errors.skillGroupSkillDevelopmentTypeChoices}
+              createEmptyOption={() => ''}
+              renderOptionEditor={({ option, setOption, removeOption, viewing }) => (
+                <div style={{ display: 'grid', gridTemplateColumns: viewing ? '1fr' : '1fr auto', gap: 8 }} >
+                  <LabeledSelect label="Group" hideLabel ariaLabel="Group" value={option} onChange={(v) => setOption(v)} options={groupOptions} disabled={loading || viewing} />
+                  {!viewing && (<button type="button" onClick={removeOption} style={{ color: '#b00020' }}>Remove</button>)}
+                </div>
+              )}
+            />
+
+            {/* Skill Category Costs */}
+            <IdCostListEditor
+              title="Skill Category Costs"
+              addButtonLabel='+ Add skill category cost'
+              rows={form.skillCategoryCosts}
+              onChangeRows={(next) =>
+                setForm((s) => ({ ...s, skillCategoryCosts: next }))
+              }
+              categoryOptions={categoryOptions}
+              loading={loading}
+              viewing={viewing}
+              error={errors.skillCategoryCosts}
+              costWidth={140}
+            />
+
+            {/* Action buttons */}
+            <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+              {!viewing && <button onClick={saveForm} disabled={hasErrors || submitting}>{submitting ? 'Submitting…' : 'Save'}</button>}
+              <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
             </div>
-            {errors.baseSpellListChoices && <div style={{ color: '#b00020', marginTop: 6 }}>{errors.baseSpellListChoices}</div>}
-          </section>
 
-          {/* Skill Bonuses */}
-          <SkillValueListEditor
-            title="Skill Bonuses"
-            rows={form.skillBonuses}
-            onChangeRows={(next) => setForm((s) => ({ ...s, skillBonuses: next }))}
-            idOptions={skillOptions}
-            loading={skillsLoading}
-            viewing={viewing}
-            error={errors.skillBonuses}
-            signedValues
-          />
-
-          {/* Category/Group bonus sections */}
-          <IdValueListEditor
-            title="Skill Category Profession Bonuses"
-            rows={form.skillCategoryProfessionBonuses}
-            onChangeRows={(next) => setForm((s) => ({ ...s, skillCategoryProfessionBonuses: next }))}
-            options={categoryOptions}
-            loading={categoriesLoading}
-            viewing={viewing}
-            error={errors.skillCategoryProfessionBonuses}
-            signedValues
-          />
-
-          <IdValueListEditor
-            title="Skill Category Special Bonuses"
-            rows={form.skillCategorySpecialBonuses}
-            onChangeRows={(next) => setForm((s) => ({ ...s, skillCategorySpecialBonuses: next }))}
-            options={categoryOptions}
-            loading={categoriesLoading}
-            viewing={viewing}
-            error={errors.skillCategorySpecialBonuses}
-            signedValues
-          />
-
-          <IdValueListEditor
-            title="Skill Group Profession Bonuses"
-            rows={form.skillGroupProfessionBonuses}
-            onChangeRows={(next) => setForm((s) => ({ ...s, skillGroupProfessionBonuses: next }))}
-            options={groupOptions}
-            loading={groupsLoading}
-            viewing={viewing}
-            error={errors.skillGroupProfessionBonuses}
-            signedValues
-          />
-
-          <IdValueListEditor
-            title="Skill Group Special Bonuses"
-            rows={form.skillGroupSpecialBonuses}
-            onChangeRows={(next) => setForm((s) => ({ ...s, skillGroupSpecialBonuses: next }))}
-            options={groupOptions}
-            loading={groupsLoading}
-            viewing={viewing}
-            error={errors.skillGroupSpecialBonuses}
-            signedValues
-          />
-
-          {/* Skill Development Types */}
-          <SkillTypeListEditor<SkillDevelopmentType>
-            title="Skill Development Types"
-            rows={form.skillDevelopmentTypes}
-            onChangeRows={(next) =>
-              setForm((s) => ({ ...s, skillDevelopmentTypes: next }))
-            }
-            idOptions={skillOptions}
-            typeOptions={developmentTypeOptions}
-            loading={skillsLoading}
-            viewing={viewing}
-            error={errors.skillDevelopmentTypes}
-          />
-
-          {/* Category / Group Skill Development Types */}
-          <IdTypeListEditor<string, SkillDevelopmentType>
-            title="Skill Category Skill Development Types"
-            rows={form.skillCategorySkillDevelopmentTypes}
-            onChangeRows={(next) =>
-              setForm((s) => ({ ...s, skillCategorySkillDevelopmentTypes: next }))
-            }
-            idOptions={categoryOptions}
-            typeOptions={developmentTypeOptions}
-            loading={categoriesLoading}
-            viewing={viewing}
-            error={errors.skillCategorySkillDevelopmentTypes}
-          />
-
-          <IdTypeListEditor<string, SkillDevelopmentType>
-            title="Skill Group Skill Development Types"
-            rows={form.skillGroupSkillDevelopmentTypes}
-            onChangeRows={(next) =>
-              setForm((s) => ({ ...s, skillGroupSkillDevelopmentTypes: next }))
-            }
-            idOptions={groupOptions}
-            typeOptions={developmentTypeOptions}
-            loading={groupsLoading}
-            viewing={viewing}
-            error={errors.skillGroupSkillDevelopmentTypes}
-          />
-
-          {/* Skill Subcategory Development Type Choices */}
-          <ChoiceListEditor<SkillDevelopmentType, string>
-            title="Skill Subcategory Development Type Choices"
-            rows={form.skillSubcategoryDevelopmentTypeChoices}
-            onChangeRows={(next) =>
-              setForm((s) => ({ ...s, skillSubcategoryDevelopmentTypeChoices: next }))
-            }
-            typeOptions={developmentTypeOptions}
-            viewing={viewing}
-            error={errors.skillSubcategoryDevelopmentTypeChoices}
-            createEmptyOption={() => ''}
-            renderOptionEditor={({ option, setOption, removeOption, viewing }) => (
-              <div style={{ display: 'grid', gridTemplateColumns: viewing ? 'minmax(280px, 1fr) 1fr' : 'minmax(280px, 1fr) 1fr auto', gap: 8, }} >
-                <LabeledSelect label="Skill" hideLabel ariaLabel="Skill" value={option} onChange={(v) => setOption(v)} options={skillOptions} disabled={skillsLoading || viewing} />
-                {!viewing && (<button type="button" onClick={removeOption} style={{ color: '#b00020' }}>Remove</button>)}
+            {/* Validation errors */}
+            {Object.values(errors).some(Boolean) && (
+              <div style={{ marginTop: 12, color: '#b00020' }}>
+                <h4 style={{ margin: '0 0 4px' }}>Please fix the following errors:</h4>
+                <ul style={{ margin: 0, paddingLeft: 20 }}>
+                  {Object.entries(errors).map(([field, error]) =>
+                    error ? <li key={field}>{error}</li> : null
+                  )}
+                </ul>
               </div>
             )}
-          />
-
-          {/* Skill Development Type Choices */}
-          <ChoiceListEditor<SkillDevelopmentType, { id: string; subcategory?: string | undefined }>
-            title="Skill Development Type Choices"
-            rows={form.skillDevelopmentTypeChoices}
-            onChangeRows={(next) =>
-              setForm((s) => ({ ...s, skillDevelopmentTypeChoices: next }))
-            }
-            typeOptions={developmentTypeOptions}
-            viewing={viewing}
-            error={errors.skillDevelopmentTypeChoices}
-            createEmptyOption={() => ({ id: '', subcategory: '' })}
-            renderOptionEditor={({ option, setOption, removeOption, viewing }) => (
-              <div style={{ display: 'grid', gridTemplateColumns: viewing ? 'minmax(280px, 1fr) 1fr' : 'minmax(280px, 1fr) 1fr auto', gap: 8, }} >
-                <LabeledSelect label="Skill" hideLabel ariaLabel="Skill" value={option.id} onChange={(v) => setOption({ id: v, subcategory: option.subcategory, })} options={skillOptions} disabled={skillsLoading || viewing} />
-                <LabeledInput label="Subcategory" hideLabel ariaLabel="Subcategory" value={option.subcategory ?? ''} onChange={(v) => setOption({ id: option.id, subcategory: v || undefined, })} disabled={viewing} />
-                {!viewing && (<button type="button" onClick={removeOption} style={{ color: '#b00020' }}>Remove</button>)}
-              </div>
-            )}
-          />
-
-          {/* Category / Group choice sections */}
-          <ChoiceListEditor<SkillDevelopmentType, string>
-            title="Skill Category Skill Development Type Choices"
-            rows={form.skillCategorySkillDevelopmentTypeChoices}
-            onChangeRows={(next) =>
-              setForm((s) => ({ ...s, skillCategorySkillDevelopmentTypeChoices: next }))
-            }
-            typeOptions={developmentTypeOptions}
-            viewing={viewing}
-            error={errors.skillCategorySkillDevelopmentTypeChoices}
-            createEmptyOption={() => ''}
-            renderOptionEditor={({ option, setOption, removeOption, viewing }) => (
-              <div style={{ display: 'grid', gridTemplateColumns: viewing ? '1fr' : '1fr auto', gap: 8 }}>
-                <LabeledSelect label="Category" hideLabel ariaLabel="Category" value={option} onChange={(v) => setOption(v)} options={categoryOptions} disabled={categoriesLoading || viewing} />
-                {!viewing && (<button type="button" onClick={removeOption} style={{ color: '#b00020' }}>Remove</button>)}
-              </div>
-            )}
-          />
-
-          <ChoiceListEditor<SkillDevelopmentType, string>
-            title="Skill Group Skill Development Type Choices"
-            rows={form.skillGroupSkillDevelopmentTypeChoices}
-            onChangeRows={(next) =>
-              setForm((s) => ({ ...s, skillGroupSkillDevelopmentTypeChoices: next }))
-            }
-            typeOptions={developmentTypeOptions}
-            viewing={viewing}
-            error={errors.skillGroupSkillDevelopmentTypeChoices}
-            createEmptyOption={() => ''}
-            renderOptionEditor={({ option, setOption, removeOption, viewing }) => (
-              <div style={{ display: 'grid', gridTemplateColumns: viewing ? '1fr' : '1fr auto', gap: 8 }} >
-                <LabeledSelect label="Group" hideLabel ariaLabel="Group" value={option} onChange={(v) => setOption(v)} options={groupOptions} disabled={groupsLoading || viewing} />
-                {!viewing && (<button type="button" onClick={removeOption} style={{ color: '#b00020' }}>Remove</button>)}
-              </div>
-            )}
-          />
-
-          {/* Skill Category Costs */}
-          <IdCostListEditor
-            title="Skill Category Costs"
-            rows={form.skillCategoryCosts}
-            onChangeRows={(next) =>
-              setForm((s) => ({ ...s, skillCategoryCosts: next }))
-            }
-            categoryOptions={categoryOptions}
-            loading={categoriesLoading}
-            viewing={viewing}
-            error={errors.skillCategoryCosts}
-            costWidth={140}
-          />
-
-          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
-            {!viewing && <button onClick={saveForm} disabled={hasErrors}>Save</button>}
-            <button onClick={cancelForm} type="button">
-              {viewing ? 'Close' : 'Cancel'}
-            </button>
           </div>
         </div>
       )}
 
       {!showForm && (
-        <DataTable<Profession>
+        <DataTable
           ref={dtRef}
           rows={rows}
           columns={columns}
           rowId={(r) => r.id}
-          initialSort={{ colId: 'name', dir: 'asc' }}
+          initialSort={{ colId: 'name', dir: 'asc' }} //
+          // search
           searchQuery={query}
           globalFilter={globalFilter}
+          // pagination (client)
           mode="client"
           page={page}
           pageSize={pageSize}
           onPageChange={setPage}
           onPageSizeChange={setPageSize}
-          pageSizeOptions={[5, 10, 20, 50, 100]}
-          tableMinWidth={1200}
-          zebra
-          hover
-          resizable
+          // styles
+          tableMinWidth={0} // allow table to shrink below container width (for better mobile support)
           persistKey="dt.profession.v1"
           ariaLabel="Professions"
         />


### PR DESCRIPTION
## Refactor: `ProfessionView` — Unified Data Loading, Submitting State & Form UX Improvements

### Summary

Refactors `ProfessionView` and related list editor components to reduce boilerplate, improve loading/submitting state handling, and polish the form UX.

### Changes

#### `src/endpoints/profession/ProfessionView.tsx`

**Unified data loading** — Replaced 6 separate `useEffect`/`mounted` patterns with a single `Promise.all` fetch. Removes 5 individual loading booleans (`booksLoading`, `spellListsLoading`, `skillsLoading`, `categoriesLoading`, `groupsLoading`) — all replaced by the shared top-level `loading` flag.

https://github.com/ArchidFreezer/rmce-ui/compare/main...prof#diff-9e8c1a03e5ab6fb3a4e7d71fb0c1e6a7bb5c5b20fa41c0588c0aada574ed98dR331-R378

**`FormErrors` named type** — Extracted the inline anonymous error shape to a dedicated top-level `FormErrors` type; `errors` and `hasErrors` state moved to the top of the component.

https://github.com/ArchidFreezer/rmce-ui/compare/main...prof#diff-9e8c1a03e5ab6fb3a4e7d71fb0c1e6a7bb5c5b20fa41c0588c0aada574ed98dR108-R130

**`submitting` state + double-submit guard** — A `submitting` boolean now prevents concurrent save/delete calls. A `Spinner` overlay is shown while a request is in flight, and the Save button is disabled + relabelled to `Submitting…`.

https://github.com/ArchidFreezer/rmce-ui/compare/main...prof#diff-9e8c1a03e5ab6fb3a4e7d71fb0c1e6a7bb5c5b20fa41c0588c0aada574ed98dR642-R730

**Inline validation error summary** — Validation errors are now also listed in a panel below the action buttons, in addition to per-field inline errors.

https://github.com/ArchidFreezer/rmce-ui/compare/main...prof#diff-9e8c1a03e5ab6fb3a4e7d71fb0c1e6a7bb5c5b20fa41c0588c0aada574ed98dR839-R848

**`computeErrors` signature tightened** — Now explicitly typed as `(draft: FormState): FormErrors`. `COST_RE` regex moved from module scope into the component body alongside it.

**`cancelForm` order fix** — `setShowForm(false)` now fires after `setViewing`, `setEditingId`, and `setErrors` are cleared.

**`startDuplicate` simplification** — `vm.name = vm.name ? \`${vm.name} (Copy)\` : vm.name` → `vm.name += ' (Copy)'`.

**`DataTable` cleanup** — Removed unused `zebra`, `hover`, `resizable`, and `pageSizeOptions` props. `tableMinWidth` changed from `1200` → `0` for better mobile support.

**Form container restructure** — Form panel wrapped in `div.form-container` to support the submitting overlay.

**Toolbar layout** — `alignItems: 'center', margin: '12px 0'` → `marginBottom: 12`.

**Code organisation** — `columns` / `globalFilter` definitions moved above the Actions section. Section comment blocks upgraded from `// ----` to `/* ---- */` style.

---

#### `src/components/inputs/IdCostListEditor.tsx`

Column headers are now conditionally rendered only when rows exist, preventing phantom header rows in empty editors.

https://github.com/ArchidFreezer/rmce-ui/compare/main...prof#diff-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0R116-R119

---

#### `src/components/inputs/IdTypeListEditor.tsx`

Same conditional header rendering as `IdCostListEditor`.

https://github.com/ArchidFreezer/rmce-ui/compare/main...prof#diff-b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1R150-R153

---

#### `src/components/inputs/SkillTypeListEditor.tsx`

Same conditional header rendering applied to all three columns (ID, subcategory, type).

https://github.com/ArchidFreezer/rmce-ui/compare/main...prof#diff-c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2R144-R148

---

### Additional

- `deleteTrainingPackage` imported from `../../api`
- `Spinner` imported from `../../components`
- Explicit `addButtonLabel` / `addRowButtonLabel` props now passed to all list editor sub-components
- All per-resource `disabled` loading flags on selects replaced with the unified `loading` flag