### PR TITLE
Don't show component labels if no entries

### DIFF
--- a/src/components/inputs/LanguageRankListEditor.tsx
+++ b/src/components/inputs/LanguageRankListEditor.tsx
@@ -159,10 +159,10 @@ export function LanguageRankListEditor({
           gap: 8,
         }}
       >
-        <div style={{ fontWeight: 600 }}>{languageColumnLabel}</div>
-        <div style={{ fontWeight: 600 }}>{spokenColumnLabel}</div>
-        <div style={{ fontWeight: 600 }}>{writtenColumnLabel}</div>
-        {showSomatic && <div style={{ fontWeight: 600 }}>{somaticColumnLabel}</div>}
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{languageColumnLabel}</div>}
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{spokenColumnLabel}</div>}
+        {rows.length > 0 && <div style={{ fontWeight: 600 }}>{writtenColumnLabel}</div>}
+        {showSomatic && rows.length > 0 && <div style={{ fontWeight: 600 }}>{somaticColumnLabel}</div>}
         {showActions && <div />}
 
         {rows.map((row, i) => (


### PR DESCRIPTION
This pull request makes a small usability improvement to the `LanguageRankListEditor` component. The change ensures that column headers are only displayed when there is at least one row present, preventing empty tables from showing unnecessary headers.

- Only render column headers (`languageColumnLabel`, `spokenColumnLabel`, `writtenColumnLabel`, and optionally `somaticColumnLabel`) if there is at least one row in the `rows` array. (`src/components/inputs/LanguageRankListEditor.tsx`)