### PR TITLE
Update SkillCategory with latest features

### DIFF
--- a/src/endpoints/skillcategory/SkillCategoryView.tsx
+++ b/src/endpoints/skillcategory/SkillCategoryView.tsx
@@ -11,6 +11,7 @@ import {
   CheckboxInput,
   LabeledInput,
   LabeledSelect,
+  Spinner,
   useConfirm, useToast,
 } from '../../components';
 
@@ -30,9 +31,9 @@ import {
 
 const prefix = 'SKILLCATEGORY_';
 
-/* ------------------------
-   Form VM (keep strings; stats as 3 slots to allow duplicates/order)
-------------------------- */
+/* ------------------------------------------------------------------ */
+/* VM types                                                           */
+/* ------------------------------------------------------------------ */
 type FormState = {
   id: string;
   group: string;                 // stores SkillGroup.id
@@ -43,6 +44,15 @@ type FormState = {
   stat1: Stat | '';
   stat2: Stat | '';
   stat3: Stat | '';
+};
+
+type FormErrors = {
+  id?: string;
+  group?: string;
+  name?: string;
+  skillProgression?: string;
+  categoryProgression?: string;
+  stats?: string;
 };
 
 const emptyVM = (): FormState => ({
@@ -85,6 +95,10 @@ const fromVM = (vm: FormState): SkillCategory => {
   };
 };
 
+/* ------------------------------------------------------------------ */
+/* View                                                               */
+/* ------------------------------------------------------------------ */
+
 export default function SkillCategoryView() {
   const dtRef = useRef<DataTableHandle>(null);
   // data
@@ -92,11 +106,10 @@ export default function SkillCategoryView() {
   const [spts, setSpts] = useState<SkillProgressionType[]>([]);
   const [groups, setGroups] = useState<SkillGroup[]>([]);
 
-  // loading/errors
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [sptLoading, setSptLoading] = useState(true);
-  const [grpLoading, setGrpLoading] = useState(true);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const hasErrors = Object.values(errors).some(Boolean);
 
   // table
   const [query, setQuery] = useState('');
@@ -107,72 +120,39 @@ export default function SkillCategoryView() {
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [viewing, setViewing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [form, setForm] = useState<FormState>(emptyVM());
-  const [errors, setErrors] = useState<{
-    id?: string | undefined;
-    group?: string | undefined;
-    name?: string | undefined;
-    skillProgression?: string | undefined;
-    categoryProgression?: string | undefined;
-    stats?: string | undefined;
-  }>({});
 
   const toast = useToast();
   const confirm = useConfirm();
 
-  // ---- load rows
+  /* ------------------------------------------------------------------ */
+  /* Load data                                                          */
+  /* ------------------------------------------------------------------ */
+
   useEffect(() => {
-    let mounted = true;
     (async () => {
       try {
-        const list = await fetchSkillcategories();
-        if (!mounted) return;
-        setRows(list);
+        const [sc, g, spt] = await Promise.all([
+          fetchSkillcategories(),
+          fetchSkillgroups(),
+          fetchSkillprogressiontypes(),
+        ]);
+        setRows(sc);
+        setGroups(g);
+        setSpts(spt);
       } catch (e) {
-        if (!mounted) return;
-        setError(e instanceof Error ? e.message : String(e));
+        setError(String(e));
       } finally {
-        if (mounted) setLoading(false);
+        setLoading(false);
       }
     })();
-    return () => { mounted = false; };
   }, []);
 
-  // ---- load skill progression types
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        const list = await fetchSkillprogressiontypes();
-        if (!mounted) return;
-        setSpts(list);
-      } catch (e) {
-        console.error('Failed to load skill progression types', e);
-      } finally {
-        if (mounted) setSptLoading(false);
-      }
-    })();
-    return () => { mounted = false; };
-  }, []);
+  /* ------------------------------------------------------------------ */
+  /* Helpers                                                            */
+  /* ------------------------------------------------------------------ */
 
-  // ---- load skill groups
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        const list = await fetchSkillgroups();
-        if (!mounted) return;
-        setGroups(list);
-      } catch (e) {
-        console.error('Failed to load skill groups', e);
-      } finally {
-        if (mounted) setGrpLoading(false);
-      }
-    })();
-    return () => { mounted = false; };
-  }, []);
-
-  // maps / options
   const sptNameById = useMemo(() => {
     const m = new Map<string, string>();
     for (const s of spts) m.set(s.id, s.name);
@@ -195,9 +175,39 @@ export default function SkillCategoryView() {
     [groups]
   );
 
-  // validation
-  const computeErrors = (draft = form) => {
+  const skillOptionsByPrefix = useMemo(() => {
+    const byPrefix = {
+      skill: sptOptions.filter((option) => !option.value.startsWith('SKILLPROGRESSIONTYPE_BD_') && !option.value.startsWith('SKILLPROGRESSIONTYPE_PP_') && !option.value.startsWith('SKILLPROGRESSIONTYPE_CATEGORY_')),
+      category: sptOptions.filter((option) => option.value.startsWith('SKILLPROGRESSIONTYPE_CATEGORY_') || option.value.startsWith('SKILLPROGRESSIONTYPE_NONE')),
+    };
+
+    return byPrefix;
+  }, [sptOptions]);
+  /* ------------------------------------------------------------------ */
+  /* Validation                                                         */
+  /* ------------------------------------------------------------------ */
+
+  function validateProgressions(skillProgId: string, categoryProgId: string): string | null {
+    const skillProg = spts.find((s) => s.id === skillProgId);
+    const categoryProg = spts.find((s) => s.id === categoryProgId);
+
+    if (!skillProg || !categoryProg) {
+      return 'Invalid progression type selected.';
+    }
+
+    if (categoryProg.id !== 'SKILLPROGRESSIONTYPE_CATEGORY_STANDARD' && categoryProg.id !== 'SKILLPROGRESSIONTYPE_NONE') {
+      return 'Category Progression must be a valid category progression type or "None".';
+    }
+    if (categoryProg.id === 'SKILLPROGRESSIONTYPE_CATEGORY_STANDARD' && skillProg.id !== 'SKILLPROGRESSIONTYPE_STANDARD') {
+      return 'If Category Progression is "Standard", Skill Progression must also be "Standard".';
+    }
+
+    return null;
+  }
+
+  const computeErrors = (draft: FormState): FormErrors => {
     const e: typeof errors = {};
+
     // ID: required, unique (on create), valid format (e.g. starts with prefix)
     if (!draft.id.trim()) e.id = 'ID is required';
     else if (!editingId && rows.some(r => r.id === draft.id.trim())) e.id = `ID "${draft.id.trim()}" already exists`;
@@ -216,110 +226,29 @@ export default function SkillCategoryView() {
 
     if (!draft.categoryProgression.trim()) e.categoryProgression = 'Category progression is required';
     else if (!sptNameById.has(draft.categoryProgression.trim())) e.categoryProgression = 'Pick a valid progression';
+    else {
+      const progressionError = validateProgressions(draft.skillProgression.trim(), draft.categoryProgression.trim());
+      if (progressionError) e.categoryProgression = progressionError;
+    }
 
     // stats: allow 0–3, but require at least one? (Adjust if you need exactly three)
     const chosen = [draft.stat1, draft.stat2, draft.stat3].filter(Boolean) as Stat[];
     const statSet = new Set(STATS);
-    if (!draft.useRealmStats && chosen.length === 0) e.stats = 'At least one stat is required when "Use Realm Stats" is checked';
+    if (!draft.useRealmStats && chosen.length === 0) e.stats = 'At least one stat is required unless "Use Realm Stats" is checked';
     else if (draft.useRealmStats && chosen.length > 0) e.stats = 'Stats must be empty when "Use Realm Stats" is checked';
     else if (!chosen.every((s) => statSet.has(s))) e.stats = 'Stats must be valid values';
 
     return e;
   };
 
-  const hasErrors = Boolean(
-    errors.id || errors.group || errors.name || errors.skillProgression || errors.categoryProgression || errors.stats
-  );
-
   useEffect(() => {
     if (!showForm || viewing) return;
-    setErrors(computeErrors());
+    setErrors(computeErrors(form));
   }, [form, showForm, viewing, sptNameById, groupNameById]);
 
-  // actions
-  const startNew = () => {
-    setViewing(false); setEditingId(null);
-    setForm(emptyVM()); setErrors({}); setShowForm(true);
-  };
-  const startView = (row: SkillCategory) => {
-    setViewing(true); setEditingId(row.id);
-    setForm(toVM(row)); setErrors({}); setShowForm(true);
-  };
-  const startEdit = (row: SkillCategory) => {
-    setViewing(false); setEditingId(row.id);
-    setForm(toVM(row)); setErrors({}); setShowForm(true);
-  };
-  const startDuplicate = (row: SkillCategory) => {
-    setViewing(false); setEditingId(null);
-    const vm = toVM(row);
-    vm.id = prefix;
-    vm.name += ' Copy';
-    setForm(vm); setErrors({}); setShowForm(true);
-  };
-  const cancelForm = () => {
-    setShowForm(false); setViewing(false); setEditingId(null); setErrors({});
-  };
-
-  const saveForm = async () => {
-    const payload = fromVM(form);
-
-    const nextErrors = computeErrors(form);
-    setErrors(nextErrors);
-    if (hasErrors) return;
-
-    const isEditing = Boolean(editingId);
-    try {
-      const opts = isEditing
-        ? { method: 'PUT' as const, useResourceIdPath: true }
-        : { method: 'POST' as const, useResourceIdPath: false };
-      await upsertSkillcategory(payload, opts);
-
-      setRows((prev) => {
-        if (isEditing) {
-          const idx = prev.findIndex((r) => r.id === payload.id);
-          if (idx >= 0) {
-            const copy = [...prev];
-            copy[idx] = { ...copy[idx], ...payload };
-            return copy;
-          }
-          return [payload, ...prev];
-        }
-        return [payload, ...prev];
-      });
-
-      setShowForm(false); setViewing(false); setEditingId(null);
-      toast({ variant: 'success', title: isEditing ? 'Updated' : 'Saved', description: `Skill category "${payload.id}" ${isEditing ? 'updated' : 'created'}.` });
-    } catch (err) {
-      toast({ variant: 'danger', title: 'Save failed', description: String(err instanceof Error ? err.message : err) });
-    }
-  };
-
-  const onDelete = async (row: SkillCategory) => {
-    const id = row?.id;
-    if (!id) return;
-    const ok = await confirm({
-      title: 'Delete Skill Category',
-      body: `Delete Skill Category "${id}"? This cannot be undone.`,
-      confirmText: 'Delete',
-      cancelText: 'Cancel',
-      tone: 'danger',
-    });
-    if (!ok) return;
-
-    const prev = rows;
-    setRows(prev.filter(a => a.id !== id));
-    try {
-      await deleteSkillcategory(id);
-      // if currently editing this item, close the form
-      if (editingId === row.id) cancelForm();
-      toast({ variant: 'success', title: 'Deleted', description: `Skill Category "${id}" deleted.` });
-    } catch (err) {
-      setRows(prev);
-      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err) });
-    }
-  };
-
-  // columns / table
+  /* ------------------------------------------------------------------ */
+  /* Table                                                              */
+  /* ------------------------------------------------------------------ */
   const columns: ColumnDef<SkillCategory>[] = useMemo(() => [
     { id: 'id', header: 'ID', accessor: (r) => r.id, sortType: 'string', minWidth: 280 },
     { id: 'name', header: 'Name', accessor: (r) => r.name, sortType: 'string', minWidth: 180 },
@@ -413,6 +342,140 @@ export default function SkillCategoryView() {
     ].some((v) => String(v ?? '').toLowerCase().includes(s));
   };
 
+  /* ------------------------------------------------------------------ */
+  /* Actions                                                            */
+  /* ------------------------------------------------------------------ */
+
+  const startNew = () => {
+    setViewing(false);
+    setEditingId(null);
+    setForm(emptyVM());
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startView = (row: SkillCategory) => {
+    setViewing(true);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startEdit = (row: SkillCategory) => {
+    setViewing(false);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startDuplicate = (row: SkillCategory) => {
+    setViewing(false);
+    setEditingId(null);
+    const vm = toVM(row);
+    vm.id = prefix;
+    vm.name += ' (Copy)';
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const cancelForm = () => {
+    setViewing(false);
+    setEditingId(null);
+    setErrors({});
+    setShowForm(false);
+  };
+
+  const saveForm = async () => {
+
+    if (submitting) return;
+
+    const nextErrors = computeErrors(form);
+    setErrors(nextErrors);
+    if (Object.values(nextErrors).some(Boolean)) {
+      return;
+    }
+
+    setSubmitting(true);
+
+    const payload = fromVM(form);
+    const isEditing = Boolean(editingId);
+
+    try {
+      const opts = isEditing
+        ? { method: 'PUT' as const, useResourceIdPath: true }
+        : { method: 'POST' as const, useResourceIdPath: false };
+
+      await upsertSkillcategory(payload, opts);
+
+      setRows((prev) => {
+        if (isEditing) {
+          const idx = prev.findIndex((r) => r.id === payload.id);
+          if (idx >= 0) {
+            const copy = [...prev];
+            copy[idx] = { ...copy[idx], ...payload };
+            return copy;
+          }
+          return [payload, ...prev];
+        }
+        return [payload, ...prev];
+      });
+
+      setShowForm(false);
+      setViewing(false);
+      setEditingId(null);
+
+      toast({
+        variant: 'success',
+        title: isEditing ? 'Updated' : 'Saved',
+        description: `Skill Category "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
+      });
+    } catch (err) {
+      toast({
+        variant: 'danger',
+        title: 'Save failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onDelete = async (row: SkillCategory) => {
+
+    if (submitting) return;
+    setSubmitting(true);
+
+    const ok = await confirm({
+      title: 'Delete Skill Category',
+      body: `Delete "${row.id}"? This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    const prev = rows;
+    setRows(prev.filter((r) => r.id !== row.id));
+
+    try {
+      await deleteSkillcategory(row.id);
+      if (editingId === row.id || viewing) cancelForm();
+      toast({ variant: 'success', title: 'Deleted', description: `Skill Category "${row.id}" deleted.` });
+    } catch (err) {
+      setRows(prev);
+      toast({ variant: 'danger', title: 'Delete failed', description: String(err instanceof Error ? err.message : err), });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  /* ------------------------------------------------------------------ */
+  /* Render                                                             */
+  /* ------------------------------------------------------------------ */
+
   if (loading) return <div>Loading…</div>;
   if (error) return <div style={{ color: 'crimson' }}>Error: {error}</div>;
 
@@ -422,7 +485,7 @@ export default function SkillCategoryView() {
 
       {/* Toolbar hidden while form visible */}
       {!showForm && (
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '12px 0' }}>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
           <button onClick={startNew}>New Skill Category</button>
           <DataTableSearchInput
             value={query}
@@ -430,117 +493,135 @@ export default function SkillCategoryView() {
             placeholder="Search skill categories…"
             aria-label="Search skill categories"
           />
+
           {/* Reset and auto-fit column widths */}
           <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
           <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
         </div>
       )}
 
-      {/* Form panel */}
+      {/* Display main Form */}
       {showForm && (
-        <div
-          className={`form-panel ${viewing ? 'form-panel--view' : ''}`}
-          style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 16, background: 'var(--panel)' }}
-        >
-          <h3 style={{ marginTop: 0 }}>
-            {viewing ? 'View Skill Category' : (editingId ? 'Edit Skill Category' : 'New Skill Category')}
-          </h3>
+        <div className="form-container">
+          {/* Simple overlay while submitting */}
+          {submitting && (<div className="overlay"><Spinner size={24} /> <span>Saving…</span> </div>)}
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-            <LabeledInput label="ID" value={form.id} onChange={makeIDOnChange<typeof form>('id', setForm, prefix)} disabled={!!editingId || viewing} error={errors.id} />
-            <LabeledInput label="Name" value={form.name} onChange={(v) => setForm(s => ({ ...s, name: v }))} disabled={viewing} error={errors.name} />
+          <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`}>
+            <h3>{viewing ? 'View' : editingId ? 'Edit' : 'New'} Skill Category</h3>
 
-            <LabeledSelect
-              label="Group"
-              value={form.group}
-              onChange={(v) => setForm((s) => ({ ...s, group: v }))}
-              options={groupOptions}
-              disabled={grpLoading || viewing}
-              error={viewing ? undefined : errors.group}
-              helperText={grpLoading ? 'Loading groups…' : undefined}
-            />
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+              <LabeledInput label="ID" value={form.id} onChange={makeIDOnChange<typeof form>('id', setForm, prefix)} disabled={!!editingId || viewing} error={errors.id} />
+              <LabeledInput label="Name" value={form.name} onChange={(v) => setForm(s => ({ ...s, name: v }))} disabled={viewing} error={errors.name} />
 
-            <CheckboxInput
-              label="Use Realm Stats"
-              checked={form.useRealmStats}
-              onChange={(c) => setForm((s) => ({ ...s, useRealmStats: c }))}
-              disabled={viewing}
-            />
+              <LabeledSelect
+                label="Group"
+                value={form.group}
+                onChange={(v) => setForm((s) => ({ ...s, group: v }))}
+                options={groupOptions}
+                disabled={loading || viewing}
+                error={viewing ? undefined : errors.group}
+                helperText={loading ? 'Loading groups…' : undefined}
+              />
 
-            <LabeledSelect
-              label="Skill Progression"
-              value={form.skillProgression}
-              onChange={(v) => setForm((s) => ({ ...s, skillProgression: v }))}
-              options={sptOptions}
-              disabled={sptLoading || viewing}
-              error={viewing ? undefined : errors.skillProgression}
-              helperText={sptLoading ? 'Loading progression types…' : undefined}
-            />
+              {/* If using Realm stats then individuals may not be selected */}
+              <CheckboxInput
+                label="Use Realm Stats"
+                checked={form.useRealmStats}
+                onChange={(c) => setForm((s) => ({ ...s, useRealmStats: c, stat1: c ? '' : s.stat1, stat2: c ? '' : s.stat2, stat3: c ? '' : s.stat3 }))}
+                disabled={viewing}
+              />
 
-            <LabeledSelect
-              label="Category Progression"
-              value={form.categoryProgression}
-              onChange={(v) => setForm((s) => ({ ...s, categoryProgression: v }))}
-              options={sptOptions}
-              disabled={sptLoading || viewing}
-              error={viewing ? undefined : errors.categoryProgression}
-              helperText={sptLoading ? 'Loading progression types…' : undefined}
-            />
+              <LabeledSelect
+                label="Skill Progression"
+                value={form.skillProgression}
+                onChange={(v) => setForm((s) => ({ ...s, skillProgression: v }))}
+                options={skillOptionsByPrefix.skill}
+                disabled={loading || viewing}
+                error={viewing ? undefined : errors.skillProgression}
+                helperText={loading ? 'Loading progression types…' : undefined}
+              />
 
-            {/* Stats (3 slots, allow duplicates & order) */}
-            <LabeledSelect
-              label="Stat #1"
-              value={form.stat1}
-              onChange={(v) => setForm((s) => ({ ...s, stat1: (v as Stat) || '' }))}
-              options={STATS}
-              disabled={viewing}
-              error={viewing ? undefined : errors.stats}
-            />
-            <LabeledSelect
-              label="Stat #2"
-              value={form.stat2}
-              onChange={(v) => setForm((s) => ({ ...s, stat2: (v as Stat) || '' }))}
-              options={STATS}
-              disabled={viewing}
-              error={undefined}
-            />
-            <LabeledSelect
-              label="Stat #3"
-              value={form.stat3}
-              onChange={(v) => setForm((s) => ({ ...s, stat3: (v as Stat) || '' }))}
-              options={STATS}
-              disabled={viewing}
-              error={undefined}
-            />
-          </div>
+              <LabeledSelect
+                label="Category Progression"
+                value={form.categoryProgression}
+                onChange={(v) => setForm((s) => ({ ...s, categoryProgression: v }))}
+                options={skillOptionsByPrefix.category}
+                disabled={loading || viewing}
+                error={viewing ? undefined : errors.categoryProgression}
+                helperText={loading ? 'Loading progression types…' : undefined}
+              />
 
-          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
-            {!viewing && <button onClick={saveForm} disabled={hasErrors}>Save</button>}
-            <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
+              {/* Stats (3 slots, allow duplicates & order) unless using Realm Stats */}
+              {!form.useRealmStats && (
+                <>
+                  <LabeledSelect
+                    label="Stat #1"
+                    value={form.stat1}
+                    onChange={(v) => setForm((s) => ({ ...s, stat1: (v as Stat) || '' }))}
+                    options={STATS}
+                    disabled={viewing}
+                    error={viewing ? undefined : errors.stats}
+                  />
+                  <LabeledSelect
+                    label="Stat #2"
+                    value={form.stat2}
+                    onChange={(v) => setForm((s) => ({ ...s, stat2: (v as Stat) || '' }))}
+                    options={STATS}
+                    disabled={viewing}
+                    error={undefined}
+                  />
+                  <LabeledSelect
+                    label="Stat #3"
+                    value={form.stat3}
+                    onChange={(v) => setForm((s) => ({ ...s, stat3: (v as Stat) || '' }))}
+                    options={STATS}
+                    disabled={viewing}
+                    error={undefined}
+                  />
+                </>
+              )}
+            </div>
+
+            {/* Action buttons */}
+            <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+              {!viewing && <button onClick={saveForm} disabled={hasErrors || submitting}>{submitting ? 'Submitting…' : 'Save'}</button>}
+              <button onClick={cancelForm} type="button">{viewing ? 'Close' : 'Cancel'}</button>
+            </div>
+
+            {/* Validation errors */}
+            {Object.values(errors).some(Boolean) && (
+              <div style={{ marginTop: 12, color: '#b00020' }}>
+                <h4 style={{ margin: '0 0 4px' }}>Please fix the following errors:</h4>
+                <ul style={{ margin: 0, paddingLeft: 20 }}>
+                  {Object.entries(errors).map(([field, error]) =>
+                    error ? <li key={field}>{error}</li> : null
+                  )}
+                </ul>
+              </div>
+            )}
           </div>
         </div>
       )}
 
       {/* Table hidden while form is visible */}
       {!showForm && (
-        <DataTable<SkillCategory>
+        <DataTable
           ref={dtRef}
           rows={rows}
           columns={columns}
           rowId={(r) => r.id}
-          initialSort={{ colId: 'name', dir: 'asc' }}
+          initialSort={{ colId: 'name', dir: 'asc' }} //
+          // search
           searchQuery={query}
           globalFilter={globalFilter}
+          // pagination (client)
           mode="client"
           page={page}
           pageSize={pageSize}
           onPageChange={setPage}
           onPageSizeChange={setPageSize}
-          pageSizeOptions={[5, 10, 20, 50, 100]}
-          tableMinWidth={0}
-          zebra
-          hover
-          resizable
+          // styles
+          tableMinWidth={0} // allow table to shrink below container width (for better mobile support)
           persistKey="dt.skillcategory.v1"
           ariaLabel="Skill categories"
         />


### PR DESCRIPTION
## Summary

Refactors and improves the `SkillCategoryView` component with better UX, stricter validation, and cleaner code organisation.

## Changes

### Data loading
- Replaced three separate sequential `useEffect` data fetches (skill categories, skill groups, progression types) with a single `Promise.all` call, reducing load time and simplifying the loading state to a single `loading` flag.
- Removed the now-redundant `sptLoading` and `grpLoading` states.

### Types & validation
- Extracted the inline `errors` object type into a named `FormErrors` type for reuse and clarity.
- Added a dedicated `validateProgressions` function that enforces cross-field rules between Skill Progression and Category Progression (e.g. Category Progression must be `STANDARD` or `None`; if Category is `STANDARD`, Skill must also be `STANDARD`).
- Fixed an incorrect validation message for the stats field ("when" → "unless").
- `computeErrors` now accepts an explicit `draft: FormState` parameter instead of defaulting to the closure-captured `form`, making it easier to reason about and test.
- `hasErrors` is now computed with `Object.values(errors).some(Boolean)` instead of a manual field-by-field boolean check.

### Form UX
- Added a `submitting` state with an overlay `Spinner` during save/delete operations to prevent double-submits.
- Save button label changes to "Submitting…" while in flight; button is disabled while `submitting` or `hasErrors`.
- Toggling **Use Realm Stats** now automatically clears the three stat fields, removing an invalid state.
- Stat fields (#1–#3) are conditionally hidden when **Use Realm Stats** is checked, decluttering the form.
- Progression type dropdowns are now pre-filtered: **Skill Progression** shows only non-BD/PP/category types; **Category Progression** shows only `CATEGORY_` and `NONE` types.
- A validation error summary is displayed below the form buttons, listing all current errors by field.
- Duplicate action renames the copy to `" (Copy)"` instead of `" Copy"`.

### Code organisation
- Action handlers (`startNew`, `startView`, `startEdit`, `startDuplicate`, `cancelForm`, `saveForm`, `onDelete`) have been moved below the table column definitions, grouping rendering concerns together.
- Added section separator comments (`VM types`, `View`, `Load data`, `Helpers`, `Validation`, `Table`, `Actions`, `Render`) throughout the file for easier navigation.
- All multi-statement action handlers have been expanded to one-statement-per-line for readability.

## Files changed
- `src/endpoints/skillcategory/SkillCategoryView.tsx`