### PR TITLE
Only display row header in AttackTableEditor when rows exist

### DIFF
--- a/src/components/inputs/AttackTableEditor.tsx
+++ b/src/components/inputs/AttackTableEditor.tsx
@@ -208,7 +208,7 @@ export function AttackTableEditor({
       )}
       {!canAdd && error && <div style={{ color: '#b00020' }}>{error}</div>}
 
-      {header}
+      {rows.length > 0 && header}
 
       <div role="grid" aria-label={`${title} grid`} style={{ display: 'grid', gap: 6 }}>
         {rows.map((r, rowIdx) => (


### PR DESCRIPTION
This pull request includes a minor UI improvement to the `AttackTableEditor` component. The change ensures that the table header is only displayed if there are rows present, preventing the header from showing up when the table is empty.