### PR TITLE
Fix empty table bug on row delete

### DIFF
--- a/src/endpoints/armourtype/ArmourTypeView.tsx
+++ b/src/endpoints/armourtype/ArmourTypeView.tsx
@@ -267,7 +267,8 @@ export default function ArmourTypeView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter(a => a.id !== id));
+    setRows((current) => current.filter((a) => a.id !== id));
+    setPage(1);
     try {
       await deleteArmourType(id);
       // if currently editing this item, close the form

--- a/src/endpoints/attacktable/AttackTableView.tsx
+++ b/src/endpoints/attacktable/AttackTableView.tsx
@@ -359,7 +359,8 @@ export default function AttacktablesView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteAttacktable(row.id);

--- a/src/endpoints/book/BookView.tsx
+++ b/src/endpoints/book/BookView.tsx
@@ -296,7 +296,8 @@ export default function BookView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteBook(row.id);

--- a/src/endpoints/climate/ClimateView.tsx
+++ b/src/endpoints/climate/ClimateView.tsx
@@ -313,7 +313,8 @@ export default function ClimateView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteClimate(row.id);

--- a/src/endpoints/creaturepace/CreaturePaceView.tsx
+++ b/src/endpoints/creaturepace/CreaturePaceView.tsx
@@ -323,7 +323,8 @@ export default function CreaturePaceView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteCreaturePace(row.id);

--- a/src/endpoints/culturetype/CultureTypeView.tsx
+++ b/src/endpoints/culturetype/CultureTypeView.tsx
@@ -568,7 +568,8 @@ export default function CultureTypeView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteCulturetype(row.id);

--- a/src/endpoints/disease/DiseaseView.tsx
+++ b/src/endpoints/disease/DiseaseView.tsx
@@ -323,7 +323,8 @@ export default function DiseaseView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteDisease(row.id);

--- a/src/endpoints/diseasetype/DiseaseTypeView.tsx
+++ b/src/endpoints/diseasetype/DiseaseTypeView.tsx
@@ -328,7 +328,8 @@ export default function DiseaseTypeView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteDiseasetype(row.id);

--- a/src/endpoints/language/LanguageView.tsx
+++ b/src/endpoints/language/LanguageView.tsx
@@ -359,7 +359,8 @@ export default function LanguagesView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteLanguage(row.id);

--- a/src/endpoints/languagecategory/LanguageCategoryView.tsx
+++ b/src/endpoints/languagecategory/LanguageCategoryView.tsx
@@ -241,7 +241,8 @@ export default function LanguageCategoryView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteLanguageCategory(row.id);

--- a/src/endpoints/poison/PoisonView.tsx
+++ b/src/endpoints/poison/PoisonView.tsx
@@ -324,7 +324,8 @@ export default function PoisonView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deletePoison(row.id);

--- a/src/endpoints/poisontype/PoisonTypeView.tsx
+++ b/src/endpoints/poisontype/PoisonTypeView.tsx
@@ -385,7 +385,8 @@ export default function PoisonTypeView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deletePoisonType(row.id);

--- a/src/endpoints/profession/ProfessionView.tsx
+++ b/src/endpoints/profession/ProfessionView.tsx
@@ -731,7 +731,8 @@ export default function ProfessionView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteProfession(row.id);

--- a/src/endpoints/race/RaceView.tsx
+++ b/src/endpoints/race/RaceView.tsx
@@ -749,7 +749,8 @@ export default function RaceView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteRace(row.id);

--- a/src/endpoints/skill/SkillView.tsx
+++ b/src/endpoints/skill/SkillView.tsx
@@ -519,7 +519,8 @@ export default function SkillView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteSkill(row.id);

--- a/src/endpoints/skillcategory/SkillCategoryView.tsx
+++ b/src/endpoints/skillcategory/SkillCategoryView.tsx
@@ -458,7 +458,8 @@ export default function SkillCategoryView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteSkillcategory(row.id);

--- a/src/endpoints/skillgroup/SkillGroupView.tsx
+++ b/src/endpoints/skillgroup/SkillGroupView.tsx
@@ -249,7 +249,8 @@ export default function SkillGroupView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteSkillgroup(row.id);

--- a/src/endpoints/skillprogressiontype/SkillProgressionTypeView.tsx
+++ b/src/endpoints/skillprogressiontype/SkillProgressionTypeView.tsx
@@ -299,7 +299,8 @@ export default function SkillProgressionTypeView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteSkillprogressiontype(row.id);

--- a/src/endpoints/specialattacktable/SpecialAttackTableView.tsx
+++ b/src/endpoints/specialattacktable/SpecialAttackTableView.tsx
@@ -364,7 +364,8 @@ export default function SpecialattacktablesView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteSpecialattacktable(row.id);

--- a/src/endpoints/spelllist/SpellListView.tsx
+++ b/src/endpoints/spelllist/SpellListView.tsx
@@ -343,7 +343,8 @@ export default function SpellListView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteSpelllist(row.id);

--- a/src/endpoints/trainingpackage/TrainingPackageView.tsx
+++ b/src/endpoints/trainingpackage/TrainingPackageView.tsx
@@ -1159,7 +1159,8 @@ export default function TrainingPackagesView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteTrainingPackage(row.id);

--- a/src/endpoints/treasurecode/TreasureCodeView.tsx
+++ b/src/endpoints/treasurecode/TreasureCodeView.tsx
@@ -272,7 +272,8 @@ export default function TreasureCodeView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteTreasurecode(row.id);
@@ -372,7 +373,7 @@ export default function TreasureCodeView() {
           rows={rows}
           columns={columns}
           rowId={(r) => r.id}
-          initialSort={{ colId: 'name', dir: 'asc' }} //
+          initialSort={{ colId: 'id', dir: 'asc' }}
           // search
           searchQuery={query}
           globalFilter={globalFilter}

--- a/src/endpoints/weapontype/WeaponTypeVIew.tsx
+++ b/src/endpoints/weapontype/WeaponTypeVIew.tsx
@@ -523,7 +523,8 @@ export default function WeaponTypeView() {
     if (!ok) return;
 
     const prev = rows;
-    setRows(prev.filter((r) => r.id !== row.id));
+    setRows((current) => current.filter((r) => r.id !== row.id));
+    setPage(1);
 
     try {
       await deleteWeaponType(row.id);


### PR DESCRIPTION
This pull request improves the deletion handling across multiple data table views in the application. Now, after deleting an item from any table, the component will reset to the first page of results. This ensures a more consistent and user-friendly experience, especially when deleting items on pages other than the first.

Key changes by theme:

**Pagination and State Management Improvements:**

* After deleting an item in any data table view (such as `ArmourTypeView`, `AttackTableView`, `BookView`, etc.), the code now resets the current page to 1 by calling `setPage(1)`. This change prevents potential issues where the current page might become invalid (e.g., empty) after a deletion. [[1]](diffhunk://#diff-4a77eaf6291bcdc64285cd78275fde916d3773f66dece3403bd891edb081ef66L270-R271) [[2]](diffhunk://#diff-cbaa16536a402befac75bcf5f0934732278925a957a58f69b67cbb6ba1a72459L362-R363) [[3]](diffhunk://#diff-4e365bdcda6d16619837d7d7f8518f089a442f33efad844d4cf433ea4a4865b3L299-R300) [[4]](diffhunk://#diff-c7721406eebbd84a8350c887d974c8115e6d081ac0dffaa36f1a70e8b61ae338L316-R317) [[5]](diffhunk://#diff-da035bbcee4dfa130a7ff1973bdd6646c1786008507ddd9446d8d94e375cd890L326-R327) [[6]](diffhunk://#diff-12e46f4db9cf586cf109b16099e984e426b369929ddbf1c998b092a2eeb5ca70L571-R572) [[7]](diffhunk://#diff-f57266d9f49def4c4df393304e4127fe91c9f305a7c6ea91629ff747a98edf48L326-R327) [[8]](diffhunk://#diff-c65014a51bd01265ba2592565f425b6bc7a743acb83cfd476cb159939b97f889L331-R332) [[9]](diffhunk://#diff-073816067d71aad3469502a3cac7a1b13d993be22395d2c18af9951efdff97edL362-R363) [[10]](diffhunk://#diff-95c01907a84d0412a7d4535ef19e0d449f7ce27a7a1ca5a3408c3b3ac45b8964L244-R245) [[11]](diffhunk://#diff-3679f6a9e572901069a96fd6bd8aed7d7ce67d1a8c89dbad62e6bbb4fcb13919L327-R328) [[12]](diffhunk://#diff-15e44ab7ebaccd871d8dcb93a11073da9d4a3b11b167e06e4ff174b4dcfc0c33L388-R389) [[13]](diffhunk://#diff-e814a8a1488823ed472eaa4f9e1db4fb803bd3691a1e4c0c2e5816e4b282f485L734-R735) [[14]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6L752-R753) [[15]](diffhunk://#diff-27a3333f6a1c30411176edece0d0c417b684f429f00840e9803d3e10d59963a3L522-R523) [[16]](diffhunk://#diff-8a2618cc9db38550e5753eb91c737a77702a4aae4698826eec202f326f6e1faeL461-R462) [[17]](diffhunk://#diff-9467991998a41bd81dbb5b8b813508e727e903663665c675ab41eaf2c83546a5L252-R253) [[18]](diffhunk://#diff-0bdaa10636dc11d9d00772caa1b8ce20114a9833a9c80d26164451ca4f8d676aL302-R303) [[19]](diffhunk://#diff-9ccb85b87a7d533ca6729fd45c7a325f4d4b8f77435e30945bf4d8323947afa8L367-R368) [[20]](diffhunk://#diff-377d6f0ee4e3fb8fda2c19f43f8c247ed1aa7a4a9b4255559c0f6a43acb791b4L346-R347)

* The `setRows` function now uses the functional update form (`setRows(current => ...)`) instead of referencing the previous variable, which is a best practice to ensure the state update is based on the latest value. (All references above)

These changes are applied consistently across all relevant table view components, improving reliability and user experience when deleting items from paginated lists.