### PR TITLE
Fix Issue #82 Skill Progression clarity

### DIFF
--- a/src/endpoints/race/RaceView.tsx
+++ b/src/endpoints/race/RaceView.tsx
@@ -434,7 +434,21 @@ export default function RaceView() {
   }, [books]);
 
   const progressionOptions = useMemo(
-    () => progressions.map((p) => ({ value: p.id, label: p.name })),
+    () => {
+      const sorted = [...progressions].sort((a, b) =>
+        a.zero - b.zero
+        || a.ten - b.ten
+        || a.twenty - b.twenty
+        || a.thirty - b.thirty
+        || a.remaining - b.remaining
+        || a.name.localeCompare(b.name)
+      );
+
+      return sorted.map((p) => ({
+        value: p.id,
+        label: `[${p.zero} : ${p.ten} : ${p.twenty} : ${p.thirty} : ${p.remaining}] - ${p.name}`,
+      }));
+    },
     [progressions],
   );
 


### PR DESCRIPTION
This pull request updates the way progression options are displayed and sorted in the `RaceView` component. The main change is that progressions are now sorted by several numeric fields and their names, and their display labels include these field values for better clarity.

**Improvements to progression options display and sorting:**

* Progressions are now sorted by `zero`, `ten`, `twenty`, `thirty`, `remaining`, and then by `name` for more logical ordering in the dropdown.
* The label for each progression option now includes the values of `zero`, `ten`, `twenty`, `thirty`, and `remaining`, making it easier for users to distinguish between options at a glance.

Closes: #82 