### PR TITLE
Add multiple sections to sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,9 @@ function Shell() {
       </header>
 
       <Sidebar
-        items={sidebarItems}
+        sections={[
+          { heading: 'Resources', items: sidebarItems, collapsible: true },
+        ]}
         open={sidebarOpen}
         onClose={() => setSidebarOpen(false)}
       />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,8 +11,29 @@ export type SidebarItem = {
   prefix?: string;
 };
 
+export type SidebarSection = {
+  id?: string;
+  heading?: string;
+  items: SidebarItem[];
+  collapsible?: boolean;
+  defaultCollapsed?: boolean;
+};
+
+type SidebarProps = {
+  items?: SidebarItem[];
+  sections?: SidebarSection[];
+  open: boolean;
+  onClose?: () => void;
+  sortInside?: boolean;
+  enableResize?: boolean;
+  minWidth?: number;
+  maxWidth?: number;
+  persistKey?: string;
+};
+
 export function Sidebar({
-  items,
+  items = [],
+  sections,
   open,
   onClose,
   sortInside = false,
@@ -20,21 +41,42 @@ export function Sidebar({
   minWidth = 140,
   maxWidth = 420,
   persistKey = 'ui.sidebar.w',
-}: {
-  items: SidebarItem[];
-  open: boolean;
-  onClose?: () => void;
-  sortInside?: boolean; // whether to sort items inside the sidebar (default: false, i.e. rely on pre-sorted input)
-  enableResize?: boolean;
-  minWidth?: number;
-  maxWidth?: number;
-  persistKey?: string;
-}) {
+}: SidebarProps) {
 
+  const normalizedSections = React.useMemo(() => {
+    const sourceSections = sections?.length
+      ? sections
+      : [{ id: 'default', items } satisfies SidebarSection];
 
-  const list = sortInside
-    ? [...items].sort((a, b) => a.label.localeCompare(b.label))
-    : items;
+    return sourceSections.map((section, index) => ({
+      ...section,
+      _key: section.id ?? section.heading ?? `section-${index}`,
+      items: sortInside
+        ? [...section.items].sort((a, b) => a.label.localeCompare(b.label))
+        : section.items,
+    }));
+  }, [items, sections, sortInside]);
+
+  const [collapsedSections, setCollapsedSections] = React.useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    for (const section of (sections?.length ? sections : [{ id: 'default', items }])) {
+      const key = section.id ?? section.heading ?? 'default';
+      initial[key] = !!section.defaultCollapsed;
+    }
+    return initial;
+  });
+
+  React.useEffect(() => {
+    setCollapsedSections((current) => {
+      const next = { ...current };
+      for (const section of normalizedSections) {
+        if (!(section._key in next)) {
+          next[section._key] = !!section.defaultCollapsed;
+        }
+      }
+      return next;
+    });
+  }, [normalizedSections]);
 
   React.useEffect(() => {
     const raw = localStorage.getItem(persistKey);
@@ -90,8 +132,10 @@ export function Sidebar({
 
   // Build a lightweight list with "path" and "prefix" only for the hook
   const countTargets = React.useMemo(
-    () => list.map(({ path, prefix }: { path: `/${string}`; prefix?: string }) => ({ path, prefix })),
-    [list]
+    () => normalizedSections.flatMap((section) =>
+      section.items.map(({ path, prefix }: { path: `/${string}`; prefix?: string }) => ({ path, prefix }))
+    ),
+    [normalizedSections]
   );
 
   const counts = useResourceCounts(countTargets); // Map<prefix, CountEntry>
@@ -108,6 +152,13 @@ export function Sidebar({
       return <span className="sidebar__count sidebar__count--error" title="Unable to load count">—</span>;
     }
     return <span className="sidebar__count" aria-label={`${it.label} items`}>{entry.count}</span>;
+  };
+
+  const toggleSection = (key: string) => {
+    setCollapsedSections((current) => ({
+      ...current,
+      [key]: !current[key],
+    }));
   };
 
   return (
@@ -131,27 +182,56 @@ export function Sidebar({
       </div>
 
       <nav className="sidebar__nav" role="navigation" aria-label="Resources">
-        <ul className="sidebar__list">
-          {list.map((it) => (
-            <li key={it.path} className="sidebar__item">
-              <NavLink
-                to={it.path}
-                className={({ isActive }) =>
-                  [
-                    'sidebar__link',
-                    isActive ? 'active' : '',
-                    it.isKnown ? 'sidebar__link--known' : 'sidebar__link--unknown', // color by kind
-                  ].join(' ').trim()
-                }
-                onClick={onClose}
-                title={it.isKnown ? 'Known resource' : 'Discovered resource'}
-              >
-                <span>{it.label}</span>
-                {getBadge(it)}
-              </NavLink>
-            </li>
-          ))}
-        </ul>
+        {normalizedSections.map((section) => {
+          const isCollapsed = !!collapsedSections[section._key];
+          const isCollapsible = !!section.collapsible;
+
+          return (
+            <section key={section._key} className="sidebar__section">
+              {section.heading && (
+                isCollapsible ? (
+                  <button
+                    type="button"
+                    className="sidebar__section-heading sidebar__section-heading--button"
+                    onClick={() => toggleSection(section._key)}
+                    aria-expanded={!isCollapsed}
+                  >
+                    <span>{section.heading}</span>
+                    <span className="sidebar__section-chevron" aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>
+                  </button>
+                ) : (
+                  <div className="sidebar__section-heading">
+                    <span>{section.heading}</span>
+                  </div>
+                )
+              )}
+
+              {!isCollapsed && (
+                <ul className="sidebar__list">
+                  {section.items.map((it) => (
+                    <li key={it.path} className="sidebar__item">
+                      <NavLink
+                        to={it.path}
+                        className={({ isActive }) =>
+                          [
+                            'sidebar__link',
+                            isActive ? 'active' : '',
+                            it.isKnown ? 'sidebar__link--known' : 'sidebar__link--unknown',
+                          ].join(' ').trim()
+                        }
+                        onClick={onClose}
+                        title={it.isKnown ? 'Known resource' : 'Discovered resource'}
+                      >
+                        <span>{it.label}</span>
+                        {getBadge(it)}
+                      </NavLink>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          );
+        })}
       </nav>
 
       <div className="sidebar__footer">

--- a/src/layout.css
+++ b/src/layout.css
@@ -232,6 +232,31 @@ button:hover {
 .sidebar__nav {
   overflow: auto;
 }
+.sidebar__section + .sidebar__section {
+  margin-top: 12px;
+}
+.sidebar__section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin: 0 0 8px;
+  padding: 4px 2px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.sidebar__section-heading--button {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+.sidebar__section-chevron {
+  font-size: 12px;
+}
 .sidebar__list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
This pull request introduces support for grouping sidebar items into collapsible sections, enhancing the organization and usability of the sidebar. The changes include updates to the `Sidebar` component to accept and render sections, logic for collapsing and expanding sections, and corresponding style updates for the new UI elements.

**Sidebar component enhancements:**

* Added a new `SidebarSection` type and updated `Sidebar` props to support an array of `sections`, each with optional headings and collapsibility. The component now normalizes sections and manages their collapsed state.
* Updated the sidebar rendering logic to display each section with an optional heading and collapsible button; clicking the button toggles the collapsed state of the section. [[1]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR185-R219) [[2]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR231-R234)
* Modified the resource count logic to aggregate counts across all section items, ensuring accurate display when sections are used.
* Added a `toggleSection` function to manage the collapsed state of each section.

**Integration and UI updates:**

* Updated `App.tsx` to pass a single "Resources" section with collapsibility enabled to the `Sidebar` component, demonstrating the new API.
* Added new CSS styles for sidebar sections, headings, collapsible buttons, and chevrons to visually distinguish and support the new sectioned sidebar layout.

Closes #98 