### PR TITLE
Remove unused CharacterBuilder fields

### DIFF
--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -1054,9 +1054,7 @@ export default function CharacterCreationView() {
         ...prev,
         skillDevelopmentTypes: [],
         categorySpecialBonuses: [],
-        categoryDevelopmentTypes: [],
         groupSpecialBonuses: [],
-        groupDevelopmentTypes: [],
       }));
       return;
     }
@@ -1072,15 +1070,7 @@ export default function CharacterCreationView() {
         id: item.id,
         value: item.value,
       })),
-      categoryDevelopmentTypes: profession.skillCategorySkillDevelopmentTypes.map((item) => ({
-        id: item.id,
-        value: item.value,
-      })),
       groupSpecialBonuses: profession.skillGroupSpecialBonuses.map((item) => ({
-        id: item.id,
-        value: item.value,
-      })),
-      groupDevelopmentTypes: profession.skillGroupSkillDevelopmentTypes.map((item) => ({
         id: item.id,
         value: item.value,
       })),

--- a/src/types/characterbuilder.ts
+++ b/src/types/characterbuilder.ts
@@ -72,11 +72,6 @@ export interface CharacterBuilder extends Named {
   realmProgressions: CharacterBuilderRealmProgression[];
   stats: CharacterBuilderStatValue[];
 
-  everymanSkills: CharacterBuilderIdOptionalSubcategory[];
-  restrictedSkills: CharacterBuilderIdOptionalSubcategory[];
-  everymanSkillCategories: string[];
-  restrictedSkillCategories: string[];
-
   skillRanks: SkillValue[];
   skillProfessionalBonuses: SkillValue[];
   skillSpecialBonuses: SkillValue[];
@@ -85,12 +80,10 @@ export interface CharacterBuilder extends Named {
   categoryRanks: PersistentValue[];
   categoryProfessionalBonuses: PersistentValue[];
   categorySpecialBonuses: PersistentValue[];
-  categoryDevelopmentTypes: PersistentDevelopmentTypeValue[];
   categoryCosts: CharacterBuilderCategoryCost[];
 
   groupProfessionalBonuses: PersistentValue[];
   groupSpecialBonuses: PersistentValue[];
-  groupDevelopmentTypes: PersistentDevelopmentTypeValue[];
 
   spellListRanks: PersistentValue[];
 
@@ -148,11 +141,6 @@ export function createEmptyCharacterBuilder(): CharacterBuilder {
     realmProgressions: [],
     stats: [],
 
-    everymanSkills: [],
-    restrictedSkills: [],
-    everymanSkillCategories: [],
-    restrictedSkillCategories: [],
-
     skillRanks: [],
     skillProfessionalBonuses: [],
     skillSpecialBonuses: [],
@@ -161,12 +149,10 @@ export function createEmptyCharacterBuilder(): CharacterBuilder {
     categoryRanks: [],
     categoryProfessionalBonuses: [],
     categorySpecialBonuses: [],
-    categoryDevelopmentTypes: [],
     categoryCosts: [],
 
     groupProfessionalBonuses: [],
     groupSpecialBonuses: [],
-    groupDevelopmentTypes: [],
 
     spellListRanks: [],
     items: [],


### PR DESCRIPTION
This pull request simplifies the character creation data structures and logic by removing unused or redundant fields related to skill and development types from both the character builder interface and the character creation view state. The changes help streamline the codebase and reduce potential confusion or maintenance overhead. All skill development type data is consolidated into the skillDevelopmentTypes field.

Removed unused fields from character builder types:

* Removed `everymanSkills`, `restrictedSkills`, `everymanSkillCategories`, and `restrictedSkillCategories` from the `CharacterBuilder` interface and the `createEmptyCharacterBuilder` function, as these are no longer used in the application logic. [[1]](diffhunk://#diff-21e2fd323f9a53c3b07ee22b21bc40289f288e123cf227633554bf4f9385e7b7L75-L79) [[2]](diffhunk://#diff-21e2fd323f9a53c3b07ee22b21bc40289f288e123cf227633554bf4f9385e7b7L151-L155)
* Removed `categoryDevelopmentTypes` and `groupDevelopmentTypes` from the `CharacterBuilder` interface and the `createEmptyCharacterBuilder` function, further simplifying the data model. [[1]](diffhunk://#diff-21e2fd323f9a53c3b07ee22b21bc40289f288e123cf227633554bf4f9385e7b7L88-L93) [[2]](diffhunk://#diff-21e2fd323f9a53c3b07ee22b21bc40289f288e123cf227633554bf4f9385e7b7L164-L169)

Simplified character creation view state management:

* Removed initialization and mapping for `categoryDevelopmentTypes` and `groupDevelopmentTypes` in the `CharacterCreationView` component, ensuring the view state only tracks necessary fields. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1057-L1059) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1075-L1086)