### PR TITLE
Refactor API functions for clarity

### DIFF
--- a/src/api/characterworkflow.ts
+++ b/src/api/characterworkflow.ts
@@ -3,7 +3,7 @@ import { sendJson } from './client';
 import type { Realm, Stat } from '../types/enum';
 import type { CharacterBuilder, PersistentValue, LanguageAbility, SkillValue } from '../types';
 
-export type PrimaryChoicesRequest = {
+export type PrimaryDefinitionRequest = {
   name: string;
   race: string;
   culture: string;
@@ -97,9 +97,15 @@ export type StatRollResponse = {
 };
 
 export async function setPrimaryDefinition(
-  payload: PrimaryChoicesRequest,
+  payload: PrimaryDefinitionRequest,
 ): Promise<CharacterBuilder> {
   return sendJson<CharacterBuilder>(PRIMARY_DEFINITION_ENDPOINT, 'POST', payload);
+}
+
+export async function setCharacterPrimaryChoices(
+  payload: CharacterBuilder,
+): Promise<CharacterBuilder> {
+  return sendJson<CharacterBuilder>(PRIMARY_CHOICES_ENDPOINT, 'POST', payload);
 }
 
 export async function getStatRollPotentials(
@@ -112,12 +118,6 @@ export async function setCharacterBuilderStats(
   payload: SetCharacterBuilderStatsRequest,
 ): Promise<SetCharacterBuilderStatsResponse> {
   return sendJson<SetCharacterBuilderStatsResponse>(SET_STATS_ENDPOINT, 'POST', payload);
-}
-
-export async function setCharacterPrimaryChoices(
-  payload: CharacterBuilder,
-): Promise<CharacterBuilder> {
-  return sendJson<CharacterBuilder>(PRIMARY_CHOICES_ENDPOINT, 'POST', payload);
 }
 
 export async function setCharacterHobbyChoices(

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -1673,8 +1673,8 @@ export default function CharacterCreationView() {
     return !e;
   })();
 
-  const showPostStatsSummary = STEP_ORDER.indexOf(step) > STEP_ORDER.indexOf('stats');
-  const postStatsSummaryValue = `${race?.name ?? ''} - ${profession?.name ?? ''} (${characterBuilder.id || ''})`.trim();
+  const showPostPrimarySummary = STEP_ORDER.indexOf(step) > STEP_ORDER.indexOf('primary');
+  const postPrimarySummaryValue = `${race?.name ?? ''} - ${profession?.name ?? ''} (${characterBuilder.id || ''})`.trim();
 
   const goPrev = () => {
     const idx = STEP_ORDER.indexOf(step);
@@ -2330,11 +2330,11 @@ export default function CharacterCreationView() {
       <h2>Character Creation</h2>
       {/* The form panel is shared across steps, with conditional rendering of step-specific inputs. */}
       <div className="form-panel" style={{ display: 'grid', gap: 14 }}>
-        {showPostStatsSummary && (
+        {showPostPrimarySummary && (
           <LabeledInput
             label="Character"
             hideLabel={true}
-            value={postStatsSummaryValue}
+            value={postPrimarySummaryValue}
             onChange={() => { }}
             inputProps={{ readOnly: true }}
             disabled


### PR DESCRIPTION
This pull request refactors the naming and handling of the "primary" step in the character creation workflow to improve clarity and consistency. The changes mainly involve renaming types and variables from "PrimaryChoices" to "PrimaryDefinition," updating related function names, and ensuring UI elements reflect these updates.

**API and Type Updates:**

* Renamed the `PrimaryChoicesRequest` type to `PrimaryDefinitionRequest` and updated the `setPrimaryDefinition` function to use the new type for payloads. (`src/api/characterworkflow.ts`, [src/api/characterworkflow.tsL6-R6](diffhunk://#diff-0f4522a4c85f1b8a61d42825272cd14449257f189427df2c9844922558d60cd8L6-R6))
* Added a new `setCharacterPrimaryChoices` function that sends a `CharacterBuilder` payload to the appropriate endpoint. (`src/api/characterworkflow.ts`, [src/api/characterworkflow.tsL100-R110](diffhunk://#diff-0f4522a4c85f1b8a61d42825272cd14449257f189427df2c9844922558d60cd8L100-R110))
* Removed the old `setCharacterPrimaryChoices` function that was previously defined after `setCharacterBuilderStats`, as it is now defined earlier in the file. (`src/api/characterworkflow.ts`, [src/api/characterworkflow.tsL117-L122](diffhunk://#diff-0f4522a4c85f1b8a61d42825272cd14449257f189427df2c9844922558d60cd8L117-L122))

**UI and Step Logic Updates:**

* Renamed variables and logic in `CharacterCreationView` from "postStatsSummary" to "postPrimarySummary" to match the updated step naming, ensuring the summary display and step checks are consistent with the new terminology. (`src/endpoints/character/CharacterCreationView.tsx`, [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1676-R1677) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L2333-R2337)