### PR TITLE
Add pure base lists

### DIFF
--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -84,6 +84,8 @@ const STEP_LABELS: Record<CharacterStep, string> = {
 };
 
 const OWN_REALM_OPEN_LISTS_CATEGORY_ID = 'SKILLCATEGORY_SPELLS_OWN_REALM_OPEN_LISTS';
+const OWN_REALM_CLOSED_LISTS_CATEGORY_ID = 'SKILLCATEGORY_SPELLS_OWN_REALM_CLOSED_LISTS';
+const PURE_EXTRA_SPELL_LIST_COUNT = 4;
 
 type StepErrors = {
   primary?: string | undefined;
@@ -990,6 +992,22 @@ export default function CharacterCreationView() {
     return map;
   }, [spellLists]);
 
+  const pureExtraSpellListOptions = useMemo(() => {
+    const fromCategories = [OWN_REALM_OPEN_LISTS_CATEGORY_ID, OWN_REALM_CLOSED_LISTS_CATEGORY_ID]
+      .flatMap((catId) => {
+        const entry = characterBuilder.categorySpellLists.find((c) => c.category === catId);
+        return entry?.spellLists ?? [];
+      });
+    // Include any already-selected IDs even if the server has since moved them
+    // out of the Open/Closed categories into the Base category.
+    const pureGroupIndex = professionBaseSpellListChoiceDefinitions.length;
+    const currentSelections = (professionBaseSpellListChoiceRows[pureGroupIndex] ?? []).filter(Boolean);
+    const allIds = Array.from(new Set([...fromCategories, ...currentSelections]));
+    return allIds
+      .map((id) => ({ value: id, label: spellListNameById.get(id) ?? id }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [characterBuilder.categorySpellLists, spellListNameById, professionBaseSpellListChoiceDefinitions.length, professionBaseSpellListChoiceRows]);
+
   const restrictedProfessions = useMemo(
     () => new Set(culture?.restrictedProfessions ?? []),
     [culture],
@@ -1566,11 +1584,19 @@ export default function CharacterCreationView() {
   }, [professionGroupDevelopmentChoiceDefinitions]);
 
   useEffect(() => {
-    setProfessionBaseSpellListChoiceRows((prev) => professionBaseSpellListChoiceDefinitions.map((choice, i) => {
-      const existing = prev[i] ?? [];
-      return Array.from({ length: choice.numChoices }, (_, slot) => existing[slot] ?? '');
-    }));
-  }, [professionBaseSpellListChoiceDefinitions]);
+    setProfessionBaseSpellListChoiceRows((prev) => {
+      const rows = professionBaseSpellListChoiceDefinitions.map((choice, i) => {
+        const existing = prev[i] ?? [];
+        return Array.from({ length: choice.numChoices }, (_, slot) => existing[slot] ?? '');
+      });
+      if (profession?.spellUserType === 'Pure') {
+        const pureGroupIndex = professionBaseSpellListChoiceDefinitions.length;
+        const existingPure = prev[pureGroupIndex] ?? [];
+        rows.push(Array.from({ length: PURE_EXTRA_SPELL_LIST_COUNT }, (_, slot) => existingPure[slot] ?? ''));
+      }
+      return rows;
+    });
+  }, [professionBaseSpellListChoiceDefinitions, profession?.spellUserType]);
 
   useEffect(() => {
     const allowedIds = new Set(weaponSkillCategoryOptions.map((opt) => opt.value));
@@ -2129,6 +2155,26 @@ export default function CharacterCreationView() {
         if (selectedSpellListIds.has(spellListId)) {
           const spellListName = spellListNameById.get(spellListId) ?? spellListId;
           return `Profession Base Spell Lists: ${spellListName} can only be selected once.`;
+        }
+        selectedSpellListIds.add(spellListId);
+      }
+    }
+
+    if (profession?.spellUserType === 'Pure') {
+      const pureGroupIndex = professionBaseSpellListChoiceDefinitions.length;
+      const pureRows = professionBaseSpellListChoiceRows[pureGroupIndex] ?? [];
+      const pureOptionIds = new Set(pureExtraSpellListOptions.map((o) => o.value));
+      for (let slot = 0; slot < PURE_EXTRA_SPELL_LIST_COUNT; slot++) {
+        const spellListId = pureRows[slot] ?? '';
+        if (!spellListId) {
+          return `Pure Spell User Extra Lists: select spell list for slot ${slot + 1}.`;
+        }
+        if (!pureOptionIds.has(spellListId)) {
+          return `Pure Spell User Extra Lists: invalid spell list in slot ${slot + 1}.`;
+        }
+        if (selectedSpellListIds.has(spellListId)) {
+          const spellListName = spellListNameById.get(spellListId) ?? spellListId;
+          return `Pure Spell User Extra Lists: ${spellListName} can only be selected once.`;
         }
         selectedSpellListIds.add(spellListId);
       }
@@ -3819,6 +3865,45 @@ export default function CharacterCreationView() {
                   })}
                 </div>
               )}
+
+              {profession?.spellUserType === 'Pure' && (() => {
+                const pureGroupIndex = professionBaseSpellListChoiceDefinitions.length;
+                const pureRows = professionBaseSpellListChoiceRows[pureGroupIndex] ?? [];
+                return (
+                  <div style={{ display: 'grid', gap: 8 }}>
+                    <h4 style={{ margin: 0 }}>Pure Spell User Extra Lists</h4>
+                    <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 10, display: 'grid', gap: 8 }}>
+                      <div style={{ color: 'var(--muted)' }}>
+                        Select {PURE_EXTRA_SPELL_LIST_COUNT} additional spell lists from Open and Closed lists.
+                      </div>
+                      {pureRows.map((spellListId, rowIndex) => {
+                        const selectedOtherIds = new Set(
+                          professionBaseSpellListChoiceRows
+                            .flatMap((group, groupIndex) => group
+                              .map((value, index) => ({ value, groupIndex, index })),
+                            )
+                            .filter((entry) => !(entry.groupIndex === pureGroupIndex && entry.index === rowIndex))
+                            .map((entry) => entry.value)
+                            .filter(Boolean),
+                        );
+                        const availableOptions = pureExtraSpellListOptions.filter(
+                          (opt) => !selectedOtherIds.has(opt.value) || opt.value === spellListId,
+                        );
+                        return (
+                          <LabeledSelect
+                            key={`pure-extra-spell-${rowIndex}`}
+                            label={`Spell List ${rowIndex + 1}`}
+                            value={spellListId}
+                            onChange={(value) => updateBaseSpellListChoiceRow(pureGroupIndex, rowIndex, value)}
+                            options={availableOptions}
+                            placeholderOption="— Select spell list —"
+                          />
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })()}
 
               {professionWeaponCategoryCostDefinitions.length > 0 && (
                 <div style={{ display: 'grid', gap: 8 }}>

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -48,7 +48,7 @@ import type {
   WeaponType,
 } from '../../types';
 
-import { DEVELOPMENT_STATS, SPELL_REALMS, STATS, type Realm, type SkillDevelopmentType, type Stat } from '../../types/enum';
+import { DEVELOPMENT_STATS, SPELL_REALMS, STATS, getStatForRealm, type Realm, type SkillDevelopmentType, type Stat } from '../../types/enum';
 import { isValidUnsignedInt, sanitizeUnsignedInt } from '../../utils';
 
 type CharacterStep =
@@ -413,10 +413,13 @@ function createEmptyTpResolution(tp: TrainingPackage): TpResolution {
   };
 }
 
-function validateTpResolution(tp: TrainingPackage, resolution: TpResolution): string | undefined {
+function validateTpResolution(tp: TrainingPackage, resolution: TpResolution, excludedStats: ReadonlySet<Stat> = new Set()): string | undefined {
   if (tp.statGainChoices && tp.statGainChoices.numChoices > 0) {
     for (let i = 0; i < tp.statGainChoices.numChoices; i++) {
       if (!resolution.statGainChoices[i]) return `${tp.name}: select stat for gain choice ${i + 1}.`;
+      if (excludedStats.has(resolution.statGainChoices[i] as Stat)) {
+        return `${tp.name}: stat gain choice ${i + 1} is already claimed by a realm stat gain.`;
+      }
     }
     const chosen = resolution.statGainChoices.filter(Boolean);
     if (new Set(chosen).size < chosen.length) return `${tp.name}: stat gain choices must be unique.`;
@@ -1261,6 +1264,12 @@ export default function CharacterCreationView() {
       for (const stat of tp.statGains ?? []) {
         claimed.add(stat);
       }
+      if (tp.realmStatGain) {
+        for (const realm of characterBuilder.magicalRealms) {
+          const stat = getStatForRealm(realm);
+          if (stat) claimed.add(stat);
+        }
+      }
       const res = tpResolutions.find((r) => r.tpId === tp.id);
       if (res) {
         for (const stat of res.statGainChoices) {
@@ -1269,7 +1278,7 @@ export default function CharacterCreationView() {
       }
     }
     return claimed;
-  }, [selectedApprenticeTrainingPackages, tpResolutions]);
+  }, [selectedApprenticeTrainingPackages, tpResolutions, characterBuilder.magicalRealms]);
 
   useEffect(() => {
     if (apprenticeStatGainsUnavailable.size === 0) return;
@@ -4568,7 +4577,15 @@ export default function CharacterCreationView() {
                 const currentTp = tpsRequiringResolution[apprenticeResolvingTpIndex];
                 const currentResolution = currentTp ? tpResolutions.find((r) => r.tpId === currentTp.id) : undefined;
                 if (!currentTp || !currentResolution) return null;
-                const resError = validateTpResolution(currentTp, currentResolution);
+                const tpRealmStatGains = new Set<Stat>(
+                  currentTp.realmStatGain
+                    ? characterBuilder.magicalRealms.flatMap((realm) => {
+                      const stat = getStatForRealm(realm);
+                      return stat ? [stat] : [];
+                    })
+                    : [],
+                );
+                const resError = validateTpResolution(currentTp, currentResolution, tpRealmStatGains);
                 const updateResolution = (updater: (r: TpResolution) => TpResolution) => {
                   setTpResolutions((prev) => prev.map((r) => r.tpId === currentTp.id ? updater(r) : r));
                 };
@@ -4583,7 +4600,7 @@ export default function CharacterCreationView() {
                       <div style={{ border: '1px solid var(--border)', borderRadius: 6, padding: 8 }}>
                         <strong>Realm Stat Gain</strong>
                         <div style={{ color: 'var(--muted)', fontSize: '0.9em', marginTop: 4 }}>
-                          This TP grants a stat gain roll for each of your magical realm stats ({characterBuilder.magicalRealms.join(', ')}).
+                          This TP grants a stat gain roll for the following stats: {[...tpRealmStatGains].join(', ')}.
                         </div>
                       </div>
                     )}
@@ -4598,7 +4615,9 @@ export default function CharacterCreationView() {
                           {Array.from({ length: currentTp.statGainChoices.numChoices }, (_, si) => {
                             const chosen = currentResolution.statGainChoices[si] ?? '';
                             const otherChosen = new Set<string>(currentResolution.statGainChoices.filter((s, i) => i !== si && s));
-                            const opts = (currentTp.statGainChoices!.options as string[]).filter((s) => !otherChosen.has(s)).map((s) => ({ value: s, label: s }));
+                            const opts = (currentTp.statGainChoices!.options as string[])
+                              .filter((s) => !otherChosen.has(s) && !tpRealmStatGains.has(s as Stat))
+                              .map((s) => ({ value: s, label: s }));
                             return (
                               <LabeledSelect
                                 key={si}

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -10,7 +10,7 @@ export const PRECIPITATIONS: ReadonlyArray<Precipitation> = [
 
 /** Enum plus reusable list for form checkboxes */
 export type Temperature = 'Hot' | 'Warm' | 'Temperate' | 'Cool' | 'Cold';
-export const TEMPERATURES: ReadonlyArray<Temperature> = [ 'Hot', 'Warm', 'Temperate', 'Cool', 'Cold'] as const;
+export const TEMPERATURES: ReadonlyArray<Temperature> = ['Hot', 'Warm', 'Temperate', 'Cool', 'Cold'] as const;
 
 /** Enum for moving manoeuvres reusable list for form checkboxes */
 export type ManoeuvreDifficulty = 'Normal' | 'Routine' | 'Easy' | 'Light' | 'Medium' | 'Hard' | 'Very Hard' | 'Extremely Hard' | 'Sheer Folly' | 'Absurd'
@@ -35,6 +35,21 @@ export const SPELL_TYPES: ReadonlyArray<SpellType> = ['Base', 'Closed', 'Open', 
 export type Stat = 'Agility' | 'Constitution' | 'Empathy' | 'Intuition' | 'Memory' | 'Presence' | 'Quickness' | 'Reasoning' | 'Self Discipline' | 'Strength';
 export const STATS: ReadonlyArray<Stat> = ['Agility', 'Constitution', 'Empathy', 'Intuition', 'Memory', 'Presence', 'Quickness', 'Reasoning', 'Self Discipline', 'Strength'] as const;
 export const DEVELOPMENT_STATS: ReadonlyArray<Stat> = ['Agility', 'Constitution', 'Empathy', 'Intuition', 'Memory'] as const;
+export const REALM_STATS: ReadonlyArray<Stat> = ['Empathy', 'Intuition', 'Presence'] as const;
+
+export function getRealmForStat(stat: Stat): Realm | undefined {
+  if (stat === 'Empathy') return 'Essence';
+  if (stat === 'Intuition') return 'Mentalism';
+  if (stat === 'Presence') return 'Channeling';
+  return undefined;
+}
+
+export function getStatForRealm(realm: Realm): Stat | undefined {
+  if (realm === 'Essence') return 'Empathy';
+  if (realm === 'Mentalism') return 'Presence';
+  if (realm === 'Channeling') return 'Intuition';
+  return undefined;
+}
 
 /** Enum for treasure value types */
 export type TreasureValueType = 'Very Poor' | 'Poor' | 'Normal' | 'Rich' | 'Very Rich' | 'Special';


### PR DESCRIPTION
This pull request enhances the character creation workflow, especially for "Pure" spell user professions, and improves validation and stat gain logic for training packages (TPs). The main changes introduce a new UI and validation for Pure spell user extra spell lists, ensure stat gain choices do not overlap with realm stat gains, and refactor utility functions for realm-stat mapping.

Key changes include:

### Pure Spell User Extra Spell Lists

* Added support for "Pure" spell user professions to select four additional spell lists from Open and Closed categories, including UI elements and validation to ensure selections are valid and unique. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R87-R88) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R998-R1013) [[3]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1569-R1608) [[4]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R2172-R2191) [[5]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R3878-R3916)

### Stat Gain Choice and Realm Stat Handling

* Updated TP resolution validation so stat gain choices cannot select stats already claimed by realm stat gains, preventing duplicate stat selections. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L414-R422) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R1267-R1272) [[3]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1254-R1281) [[4]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L4486-R4588) [[5]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L4516-R4620)
* Improved the display and logic for realm stat gains, showing the actual stats granted and disabling them as options in stat gain choices.

### Realm/Stat Mapping Utilities

* Added `getStatForRealm` and `getRealmForStat` utility functions to map between realms and stats, and exposed `REALM_STATS` for easier stat management. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L51-R51) [[2]](diffhunk://#diff-c03d2752e8ea0c512e7538996f72d27e80241ed7a02e9100dbdfbff721b92186R38-R52)

These changes collectively improve the robustness and user experience of character creation, particularly for advanced spell user options and training package stat assignments.