### PR TITLE
Add formatting and tooltips to controls

### DIFF
--- a/src/components/inputs/LabeledSelect.tsx
+++ b/src/components/inputs/LabeledSelect.tsx
@@ -4,6 +4,7 @@ export interface LabeledSelectOption {
   label: string;
   value: string;
   disabled?: boolean | undefined;   // Fix A-compatible
+  title?: string | undefined;
 }
 
 export interface LabeledSelectProps {
@@ -81,7 +82,7 @@ export function LabeledSelect({
       >
         <option value="">{placeholderOption}</option>
         {norm.map((opt) => (
-          <option key={opt.value} value={opt.value} disabled={!!opt.disabled}>
+          <option key={opt.value} value={opt.value} disabled={!!opt.disabled} title={opt.title}>
             {opt.label}
           </option>
         ))}

--- a/src/components/inputs/RichSelect.tsx
+++ b/src/components/inputs/RichSelect.tsx
@@ -15,6 +15,8 @@ export interface RichSelectOption {
    */
   searchText?: string;
   disabled?: boolean;
+  /** Native tooltip shown on hover over the dropdown item. */
+  title?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -320,6 +322,7 @@ export function RichSelect({
                   aria-selected={isSelected}
                   aria-disabled={opt.disabled}
                   aria-label={text}
+                  title={opt.title}
                   onMouseEnter={() => !opt.disabled && setActiveIndex(i)}
                   onMouseLeave={() => setActiveIndex(-1)}
                   onMouseDown={(e) => { e.preventDefault(); selectOption(opt); }}

--- a/src/components/inputs/RichSelect.tsx
+++ b/src/components/inputs/RichSelect.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useId, useRef, useState, type CSSProperties, type KeyboardEvent, type ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Option type
+// ---------------------------------------------------------------------------
+
+export interface RichSelectOption {
+  value: string;
+  /** ReactNode label rendered inside both the trigger and the dropdown. */
+  label: ReactNode;
+  /**
+   * Plain-text equivalent of `label`. Used for keyboard type-ahead and
+   * accessible `aria-label` on each option. Required when `label` is not a
+   * plain string.
+   */
+  searchText?: string;
+  disabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface RichSelectProps {
+  label: string;
+  hideLabel?: boolean;
+  ariaLabel?: string;
+  value: string;
+  onChange: (val: string) => void;
+  options: readonly RichSelectOption[];
+  disabled?: boolean;
+  id?: string;
+  required?: boolean;
+  error?: string;
+  helperText?: string;
+  placeholderOption?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience label component
+// ---------------------------------------------------------------------------
+
+/**
+ * A two-part option label: `primary` text is shown normally and `secondary`
+ * text is shown in a smaller muted style to the right.
+ *
+ * Example:
+ *   <RichOptionLabel primary="Firebolt" secondary="Own Realm Open Lists" />
+ */
+export function RichOptionLabel({ primary, secondary }: { primary: string; secondary?: string }) {
+  return (
+    <>
+      <span>{primary}</span>
+      {secondary && (
+        <span
+          style={{
+            color: 'inherit',
+            opacity: 0.65,
+            fontSize: '0.85em',
+            marginLeft: 8,
+          }}
+        >
+          — {secondary}
+        </span>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// RichSelect
+// ---------------------------------------------------------------------------
+
+export function RichSelect({
+  label,
+  hideLabel = false,
+  ariaLabel,
+  value,
+  onChange,
+  options,
+  disabled = false,
+  id,
+  required,
+  error,
+  helperText,
+  placeholderOption = '— Select —',
+}: RichSelectProps) {
+  const autoId = useId();
+  const selectId = id ?? `rs-${autoId}`;
+  const listboxId = `${selectId}-listbox`;
+  const errorId = error ? `${selectId}-error` : undefined;
+  const helperId = helperText ? `${selectId}-help` : undefined;
+  const describedBy = [errorId, helperId].filter(Boolean).join(' ') || undefined;
+
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const selectedIndex = options.findIndex((o) => o.value === value);
+  const selectedOption = selectedIndex >= 0 ? options[selectedIndex] : undefined;
+
+  const computedAriaLabel = !label || hideLabel ? (ariaLabel ?? label ?? undefined) : undefined;
+
+  /** Resolve the plain-text name of an option for type-ahead / a11y. */
+  function optionText(opt: RichSelectOption): string {
+    if (typeof opt.label === 'string') return opt.label;
+    return opt.searchText ?? opt.value;
+  }
+
+  // ── Close on outside click ────────────────────────────────────────────────
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  // ── Scroll active item into view ──────────────────────────────────────────
+  useEffect(() => {
+    if (!open || activeIndex < 0) return;
+    const li = listRef.current?.children[activeIndex] as HTMLElement | undefined;
+    li?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, open]);
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+  function openList() {
+    if (disabled) return;
+    setOpen(true);
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : firstEnabledIndex());
+  }
+
+  function firstEnabledIndex(): number {
+    return options.findIndex((o) => !o.disabled);
+  }
+
+  function lastEnabledIndex(): number {
+    return options.reduce((acc: number, o, i) => (!o.disabled ? i : acc), -1);
+  }
+
+  function nextEnabled(from: number): number {
+    let i = from + 1;
+    while (i < options.length && options[i]?.disabled) i++;
+    return i < options.length ? i : from;
+  }
+
+  function prevEnabled(from: number): number {
+    let i = from - 1;
+    while (i >= 0 && options[i]?.disabled) i--;
+    return i >= 0 ? i : from;
+  }
+
+  function selectOption(opt: RichSelectOption) {
+    if (opt.disabled) return;
+    onChange(opt.value);
+    setOpen(false);
+  }
+
+  // ── Keyboard type-ahead ───────────────────────────────────────────────────
+  const typeaheadRef = useRef('');
+  const typeaheadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function handleTypeahead(char: string) {
+    typeaheadRef.current += char.toLowerCase();
+    if (typeaheadTimerRef.current) clearTimeout(typeaheadTimerRef.current);
+    typeaheadTimerRef.current = setTimeout(() => { typeaheadRef.current = ''; }, 500);
+
+    const prefix = typeaheadRef.current;
+    const match = options.findIndex((o) => !o.disabled && optionText(o).toLowerCase().startsWith(prefix));
+    if (match >= 0) setActiveIndex(match);
+  }
+
+  // ── Keyboard handler on the trigger button ────────────────────────────────
+  function handleKeyDown(e: KeyboardEvent<HTMLButtonElement>) {
+    if (disabled) return;
+    switch (e.key) {
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (!open) { openList(); }
+        else if (activeIndex >= 0 && options[activeIndex]) { selectOption(options[activeIndex]!); }
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        if (!open) { openList(); break; }
+        setActiveIndex((i) => nextEnabled(i));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        if (!open) { openList(); break; }
+        setActiveIndex((i) => prevEnabled(i));
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(firstEnabledIndex());
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(lastEnabledIndex());
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        break;
+      case 'Tab':
+        setOpen(false);
+        break;
+      default:
+        if (e.key.length === 1) {
+          if (!open) openList();
+          handleTypeahead(e.key);
+        }
+    }
+  }
+
+  // ── Styles ────────────────────────────────────────────────────────────────
+  const triggerStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    padding: 8,
+    border: error ? '1px solid #b00020' : '1px solid var(--border)',
+    background: 'var(--bg)',
+    color: disabled ? 'var(--muted)' : 'var(--text)',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    textAlign: 'left',
+    fontSize: 14,
+    boxSizing: 'border-box',
+  };
+
+  // ── Render ────────────────────────────────────────────────────────────────
+  return (
+    <div ref={containerRef} style={{ display: 'grid', gap: 6, fontSize: 14 }}>
+      {!hideLabel && (
+        <label htmlFor={selectId}>
+          {label}
+          {required ? ' *' : ''}
+        </label>
+      )}
+
+      <div style={{ position: 'relative' }}>
+        <button
+          id={selectId}
+          type="button"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-activedescendant={open && activeIndex >= 0 ? `${selectId}-opt-${activeIndex}` : undefined}
+          aria-label={computedAriaLabel}
+          aria-invalid={!!error}
+          aria-describedby={describedBy}
+          aria-required={required}
+          disabled={disabled}
+          onClick={() => (open ? setOpen(false) : openList())}
+          onKeyDown={handleKeyDown}
+          style={triggerStyle}
+        >
+          <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {selectedOption
+              ? selectedOption.label
+              : <span style={{ color: 'var(--muted)' }}>{placeholderOption}</span>}
+          </span>
+          <span aria-hidden="true" style={{ marginLeft: 8, fontSize: '0.7em', flexShrink: 0 }}>
+            {open ? '▲' : '▼'}
+          </span>
+        </button>
+
+        {open && (
+          <ul
+            id={listboxId}
+            ref={listRef}
+            role="listbox"
+            aria-label={label}
+            style={{
+              position: 'absolute',
+              zIndex: 1000,
+              top: '100%',
+              left: 0,
+              right: 0,
+              maxHeight: 260,
+              overflowY: 'auto',
+              margin: 0,
+              padding: 0,
+              listStyle: 'none',
+              border: '1px solid var(--border)',
+              background: 'var(--bg)',
+              boxShadow: '0 4px 12px rgba(0,0,0,0.18)',
+            }}
+          >
+            {options.map((opt, i) => {
+              const isSelected = opt.value === value;
+              const isActive = i === activeIndex;
+              const text = optionText(opt);
+
+              let bg: string;
+              if (isActive) bg = 'var(--primary, #0078d4)';
+              else if (isSelected) bg = 'var(--primary-subtle, rgba(0,120,212,0.12))';
+              else bg = 'transparent';
+
+              const optStyle: CSSProperties = {
+                padding: '7px 8px',
+                cursor: opt.disabled ? 'not-allowed' : 'pointer',
+                background: bg,
+                color: isActive ? '#fff' : opt.disabled ? 'var(--muted)' : 'var(--text)',
+                fontSize: 14,
+                userSelect: 'none',
+              };
+
+              return (
+                <li
+                  key={opt.value}
+                  id={`${selectId}-opt-${i}`}
+                  role="option"
+                  aria-selected={isSelected}
+                  aria-disabled={opt.disabled}
+                  aria-label={text}
+                  onMouseEnter={() => !opt.disabled && setActiveIndex(i)}
+                  onMouseLeave={() => setActiveIndex(-1)}
+                  onMouseDown={(e) => { e.preventDefault(); selectOption(opt); }}
+                  style={optStyle}
+                >
+                  {opt.label}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {helperText && !error && (
+        <span id={helperId} style={{ color: 'var(--muted)', fontSize: 12 }}>
+          {helperText}
+        </span>
+      )}
+      {error && (
+        <span id={errorId} style={{ color: '#b00020', fontSize: 12 }}>
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/inputs/RichSelect.tsx
+++ b/src/components/inputs/RichSelect.tsx
@@ -235,7 +235,7 @@ export function RichSelect({
 
   // ── Render ────────────────────────────────────────────────────────────────
   return (
-    <div ref={containerRef} style={{ display: 'grid', gap: 6, fontSize: 14 }}>
+    <div ref={containerRef} style={{ display: 'grid', gap: 6, fontSize: 14, width: '100%' }}>
       {!hideLabel && (
         <label htmlFor={selectId}>
           {label}

--- a/src/components/inputs/RichSelect.tsx
+++ b/src/components/inputs/RichSelect.tsx
@@ -23,17 +23,17 @@ export interface RichSelectOption {
 
 export interface RichSelectProps {
   label: string;
-  hideLabel?: boolean;
-  ariaLabel?: string;
+  hideLabel?: boolean | undefined;
+  ariaLabel?: string | undefined;
   value: string;
   onChange: (val: string) => void;
   options: readonly RichSelectOption[];
-  disabled?: boolean;
-  id?: string;
-  required?: boolean;
-  error?: string;
-  helperText?: string;
-  placeholderOption?: string;
+  disabled?: boolean | undefined;
+  id?: string | undefined;
+  required?: boolean | undefined;
+  error?: string | undefined;
+  helperText?: string | undefined;
+  placeholderOption?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/inputs/index.ts
+++ b/src/components/inputs/index.ts
@@ -19,5 +19,6 @@ export * from './SkillTypeListEditor';
 export * from './SkillValueListEditor';
 export * from './SpellListCategoryRankEditor';
 export * from './SpellListRankEditor';
+export * from './RichSelect';
 export * from './StatGainChoiceEditor';
 export * from './TextNumberListEditor';

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+﻿import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 
 import {
   applyApprenticeshipChoices,
@@ -27,6 +27,9 @@ import {
   CheckboxInput,
   LabeledInput,
   LabeledSelect,
+  RichOptionLabel,
+  RichSelect,
+  type RichSelectOption,
   Spinner,
   useToast,
 } from '../../components';
@@ -996,16 +999,31 @@ export default function CharacterCreationView() {
     return map;
   }, [spellLists]);
 
-  const pureExtraSpellListOptions = useMemo(() => {
-    // Build a map of spellListId → categoryId for Open/Closed categories
-    const spellListCategoryMap = new Map<string, string>();
-    for (const catId of [OWN_REALM_OPEN_LISTS_CATEGORY_ID, OWN_REALM_CLOSED_LISTS_CATEGORY_ID]) {
-      const entry = characterBuilder.categorySpellLists.find((c) => c.category === catId);
-      for (const slId of entry?.spellLists ?? []) {
-        spellListCategoryMap.set(slId, catId);
+  /** Global reverse map: spellListId → categoryId, covering all categories. */
+  const spellListCategoryById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const entry of characterBuilder.categorySpellLists) {
+      for (const slId of entry.spellLists) {
+        map.set(slId, entry.category);
       }
     }
+    return map;
+  }, [characterBuilder.categorySpellLists]);
 
+  /** Convert a spell list ID to a RichSelectOption with category shown muted. */
+  const toSpellListRichOption = useCallback((id: string): RichSelectOption => {
+    const catId = spellListCategoryById.get(id);
+    const rawCatName = catId ? (categoryNameById.get(catId) ?? catId) : undefined;
+    const catName = rawCatName?.replace(/^.*?\s-\s/, '');
+    const slName = spellListNameById.get(id) ?? id;
+    return {
+      value: id,
+      label: <RichOptionLabel primary={slName} {...(catName ? { secondary: catName } : {})} />,
+      searchText: catName ? `${slName} — ${catName}` : slName,
+    };
+  }, [spellListCategoryById, categoryNameById, spellListNameById]);
+
+  const pureExtraSpellListOptions = useMemo(() => {
     const fromCategories = [OWN_REALM_OPEN_LISTS_CATEGORY_ID, OWN_REALM_CLOSED_LISTS_CATEGORY_ID]
       .flatMap((catId) => {
         const entry = characterBuilder.categorySpellLists.find((c) => c.category === catId);
@@ -1017,15 +1035,9 @@ export default function CharacterCreationView() {
     const currentSelections = (professionBaseSpellListChoiceRows[pureGroupIndex] ?? []).filter(Boolean);
     const allIds = Array.from(new Set([...fromCategories, ...currentSelections]));
     return allIds
-      .map((id) => {
-        const catId = spellListCategoryMap.get(id);
-        const rawCatName = catId ? (categoryNameById.get(catId) ?? catId) : undefined;
-        const catName = rawCatName?.replace(/^.*?\s-\s/, '');
-        const slName = spellListNameById.get(id) ?? id;
-        return { value: id, label: catName ? `${slName} — ${catName}` : slName };
-      })
-      .sort((a, b) => a.label.localeCompare(b.label));
-  }, [characterBuilder.categorySpellLists, spellListNameById, categoryNameById, professionBaseSpellListChoiceDefinitions.length, professionBaseSpellListChoiceRows]);
+      .map(toSpellListRichOption)
+      .sort((a, b) => a.searchText!.localeCompare(b.searchText!));
+  }, [characterBuilder.categorySpellLists, toSpellListRichOption, professionBaseSpellListChoiceDefinitions.length, professionBaseSpellListChoiceRows]);
 
   const restrictedProfessions = useMemo(
     () => new Set(culture?.restrictedProfessions ?? []),
@@ -3865,8 +3877,8 @@ export default function CharacterCreationView() {
                   {professionBaseSpellListChoiceDefinitions.map((choice, choiceIndex) => {
                     const rows = professionBaseSpellListChoiceRows[choiceIndex] ?? [];
                     const options = choice.options
-                      .map((id) => ({ value: id, label: spellListNameById.get(id) ?? id }))
-                      .sort((a, b) => a.label.localeCompare(b.label));
+                      .map(toSpellListRichOption)
+                      .sort((a, b) => a.searchText!.localeCompare(b.searchText!));
                     return (
                       <div key={`prof-base-spell-${choiceIndex}`} style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 10, display: 'grid', gap: 8 }}>
                         <div style={{ color: 'var(--muted)' }}>
@@ -3885,7 +3897,7 @@ export default function CharacterCreationView() {
                             );
                             const availableOptions = options.filter((opt) => !selectedOtherIds.has(opt.value) || opt.value === spellListId);
                             return (
-                              <LabeledSelect
+                              <RichSelect
                                 key={`prof-base-spell-${choiceIndex}-${rowIndex}`}
                                 label={`Spell List ${rowIndex + 1}`}
                                 value={spellListId}
@@ -3926,7 +3938,7 @@ export default function CharacterCreationView() {
                           (opt) => !selectedOtherIds.has(opt.value) || opt.value === spellListId,
                         );
                         return (
-                          <LabeledSelect
+                          <RichSelect
                             key={`pure-extra-spell-${rowIndex}`}
                             label={`Spell List ${rowIndex + 1}`}
                             value={spellListId}
@@ -4288,11 +4300,11 @@ export default function CharacterCreationView() {
               </div>
 
               {spellListRanksBudget > 0 && (
-                <LabeledSelect
+                <RichSelect
                   label={`Hobby Spell List (${spellListRanksBudget} ranks)`}
                   value={hobbySpellListId}
                   onChange={(v) => setHobbySpellListId(v)}
-                  options={hobbySpellListOptions.map((id) => ({ value: id, label: spellListNameById.get(id) ?? id }))}
+                  options={hobbySpellListOptions.map(toSpellListRichOption)}
                   error={errors.hobby && !hobbySpellListId ? 'Required' : undefined}
                 />
               )}
@@ -4884,7 +4896,7 @@ export default function CharacterCreationView() {
                             const totalAllocated = allocs.reduce((s, a) => s + a.ranks, 0);
                             const remainingRanks = choiceDef.value - totalAllocated;
                             const usedIds = new Set(allocs.map((a) => a.id).filter(Boolean));
-                            const availableSlOpts = choiceDef.options.filter((slId) => slId).map((slId) => ({ value: slId, label: spellListNameById.get(slId) ?? slId }));
+                            const availableSlOpts = choiceDef.options.filter((slId) => slId).map(toSpellListRichOption);
                             return (
                               <div key={gi}>
                                 <div style={{ color: 'var(--muted)', fontSize: '0.9em', marginBottom: 4 }}>
@@ -4897,7 +4909,7 @@ export default function CharacterCreationView() {
                                     return (
                                       <div key={ai} style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}>
                                         <div style={{ flex: 1 }}>
-                                          <LabeledSelect
+                                          <RichSelect
                                             label={`Spell List ${ai + 1}`}
                                             value={alloc.id}
                                             onChange={(v) => updateResolution((r) => ({ ...r, spellListChoices: r.spellListChoices.map((g, gIdx) => gIdx !== gi ? g : g.map((a, aIdx) => aIdx !== ai ? a : { ...a, id: v })) }))}
@@ -4937,7 +4949,7 @@ export default function CharacterCreationView() {
                             const usedIds = new Set(allocs.map((a) => a.id).filter(Boolean));
                             const aggregatedSlOpts = choiceDef.options.flatMap((catId) =>
                               (characterBuilder.categorySpellLists.find((c) => c.category === catId)?.spellLists ?? [])
-                                .map((slId) => ({ value: slId, label: spellListNameById.get(slId) ?? slId }))
+                                .map(toSpellListRichOption)
                             );
                             return (
                               <div key={gi}>
@@ -4951,7 +4963,7 @@ export default function CharacterCreationView() {
                                     return (
                                       <div key={ai} style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}>
                                         <div style={{ flex: 1 }}>
-                                          <LabeledSelect
+                                          <RichSelect
                                             label={`Spell List ${ai + 1}`}
                                             value={alloc.id}
                                             onChange={(v) => updateResolution((r) => ({ ...r, spellListCategoryChoices: r.spellListCategoryChoices.map((g, gIdx) => gIdx !== gi ? g : g.map((a, aIdx) => aIdx !== ai ? a : { ...a, id: v })) }))}
@@ -5436,7 +5448,7 @@ export default function CharacterCreationView() {
                           placeholderOption="— Select category —"
                         />
                         {apprenticeSelectedSpellCategory && apprenticeSpellListsInSelectedCategory.length > 0 && (
-                          <LabeledSelect
+                          <RichSelect
                             label="Spell List"
                             hideLabel={true}
                             value=""
@@ -5447,7 +5459,7 @@ export default function CharacterCreationView() {
                                 setApprenticeAddingSpellList(false);
                               }
                             }}
-                            options={apprenticeSpellListsInSelectedCategory.map((sl) => ({ value: sl.id, label: sl.name }))}
+                            options={apprenticeSpellListsInSelectedCategory.map((sl) => toSpellListRichOption(sl.id))}
                             placeholderOption="— Select spell list —"
                           />
                         )}

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -858,62 +858,6 @@ export default function CharacterCreationView() {
     [profession],
   );
 
-  const raceEverymanSkillOptions = useMemo(() => {
-    return raceEverymanChoiceDefinitions.map((choice) => {
-      const categorySet = new Set(choice.options);
-      const rows = skills
-        .filter((s) => categorySet.has(s.category))
-        .slice()
-        .sort((a, b) => a.name.localeCompare(b.name));
-      return rows.map((s) => ({ value: s.id, label: s.name }));
-    });
-  }, [raceEverymanChoiceDefinitions, skills]);
-
-  const cultureTypeCategorySkillOptions = useMemo(() => {
-    return cultureTypeCategorySkillRankDefinitions.map((choice) => {
-      const rows = skillIdsByCategory.get(choice.id) ?? [];
-      return rows.map((s) => ({ value: s.id, label: s.name }));
-    });
-  }, [cultureTypeCategorySkillRankDefinitions, skillIdsByCategory]);
-
-  const professionSkillDevelopmentOptions = useMemo(() => {
-    return professionSkillDevelopmentChoiceDefinitions.map((choice) => {
-      const ids = new Set(choice.options.map((option) => option.id));
-      return skills
-        .filter((s) => ids.has(s.id))
-        .slice()
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map((s) => ({ value: s.id, label: s.name }));
-    });
-  }, [professionSkillDevelopmentChoiceDefinitions, skills]);
-
-  const professionCategoryDevelopmentOptions = useMemo(() => {
-    return professionCategoryDevelopmentChoiceDefinitions.map((choice) => {
-      const categorySet = new Set(choice.options);
-      return skills
-        .filter((s) => categorySet.has(s.category))
-        .slice()
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map((s) => ({ value: s.id, label: s.name }));
-    });
-  }, [professionCategoryDevelopmentChoiceDefinitions, skills]);
-
-  const professionGroupDevelopmentOptions = useMemo(() => {
-    return professionGroupDevelopmentChoiceDefinitions.map((choice) => {
-      const categorySet = new Set<string>();
-      for (const groupId of choice.options) {
-        for (const categoryId of categoryIdsByGroup.get(groupId) ?? []) {
-          categorySet.add(categoryId);
-        }
-      }
-      return skills
-        .filter((s) => categorySet.has(s.category))
-        .slice()
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map((s) => ({ value: s.id, label: s.name }));
-    });
-  }, [professionGroupDevelopmentChoiceDefinitions, categoryIdsByGroup, skills]);
-
   const categoryNameById = useMemo(() => {
     const groupNameById = new Map<string, string>();
     for (const g of groups) groupNameById.set(g.id, g.name);
@@ -1022,6 +966,72 @@ export default function CharacterCreationView() {
       searchText: catName ? `${slName} — ${catName}` : slName,
     };
   }, [spellListCategoryById, categoryNameById, spellListNameById]);
+
+  /** Convert a Skill to a RichSelectOption with category name shown muted. */
+  const toSkillRichOption = useCallback((s: { id: string; name: string; category: string }): RichSelectOption => {
+    const catName = categoryNameById.get(s.category);
+    return {
+      value: s.id,
+      label: <RichOptionLabel primary={s.name} {...(catName ? { secondary: catName } : {})} />,
+      searchText: catName ? `${s.name} — ${catName}` : s.name,
+    };
+  }, [categoryNameById]);
+
+  const raceEverymanSkillOptions = useMemo(() => {
+    return raceEverymanChoiceDefinitions.map((choice) => {
+      const categorySet = new Set(choice.options);
+      return skills
+        .filter((s) => categorySet.has(s.category))
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(toSkillRichOption);
+    });
+  }, [raceEverymanChoiceDefinitions, skills, toSkillRichOption]);
+
+  const cultureTypeCategorySkillOptions = useMemo(() => {
+    return cultureTypeCategorySkillRankDefinitions.map((choice) => {
+      const rows = skillIdsByCategory.get(choice.id) ?? [];
+      return rows.map(toSkillRichOption);
+    });
+  }, [cultureTypeCategorySkillRankDefinitions, skillIdsByCategory, toSkillRichOption]);
+
+  const professionSkillDevelopmentOptions = useMemo(() => {
+    return professionSkillDevelopmentChoiceDefinitions.map((choice) => {
+      const ids = new Set(choice.options.map((option) => option.id));
+      return skills
+        .filter((s) => ids.has(s.id))
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(toSkillRichOption);
+    });
+  }, [professionSkillDevelopmentChoiceDefinitions, skills, toSkillRichOption]);
+
+  const professionCategoryDevelopmentOptions = useMemo(() => {
+    return professionCategoryDevelopmentChoiceDefinitions.map((choice) => {
+      const categorySet = new Set(choice.options);
+      return skills
+        .filter((s) => categorySet.has(s.category))
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(toSkillRichOption);
+    });
+  }, [professionCategoryDevelopmentChoiceDefinitions, skills, toSkillRichOption]);
+
+  const professionGroupDevelopmentOptions = useMemo(() => {
+    return professionGroupDevelopmentChoiceDefinitions.map((choice) => {
+      const categorySet = new Set<string>();
+      for (const groupId of choice.options) {
+        for (const categoryId of categoryIdsByGroup.get(groupId) ?? []) {
+          categorySet.add(categoryId);
+        }
+      }
+      return skills
+        .filter((s) => categorySet.has(s.category))
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(toSkillRichOption);
+    });
+  }, [professionGroupDevelopmentChoiceDefinitions, categoryIdsByGroup, skills, toSkillRichOption]);
 
   const pureExtraSpellListOptions = useMemo(() => {
     const fromCategories = [OWN_REALM_OPEN_LISTS_CATEGORY_ID, OWN_REALM_CLOSED_LISTS_CATEGORY_ID]
@@ -1192,12 +1202,12 @@ export default function CharacterCreationView() {
   }, [backgroundState]);
 
   const backgroundSkillBonusOptions = useMemo(
-    () =>
+    (): RichSelectOption[] =>
       skills
         .slice()
         .sort((a, b) => a.name.localeCompare(b.name))
-        .map((s) => ({ value: s.id, label: s.name })),
-    [skills],
+        .map(toSkillRichOption),
+    [skills, toSkillRichOption],
   );
 
   const selectedBackgroundSkillSet = useMemo(
@@ -3559,33 +3569,44 @@ export default function CharacterCreationView() {
                         <div style={{ color: 'var(--muted)' }}>
                           Choice #{choiceIndex + 1}: select {choice.numChoices} skill{choice.numChoices === 1 ? '' : 's'}.
                         </div>
-                        {rows.map((row, rowIndex) => (
-                          <div key={`race-everyman-${choiceIndex}-${rowIndex}`} style={{ display: 'grid', gap: 6, gridTemplateColumns: 'minmax(260px, 1fr) minmax(220px, 1fr)' }}>
-                            <LabeledSelect
-                              label={`Skill ${rowIndex + 1}`}
-                              value={row.id}
-                              onChange={(value) => updateGroupedSkillChoiceRow(setRaceEverymanChoiceRows, choiceIndex, rowIndex, {
-                                id: value,
-                                subcategory: '',
-                              })}
-                              options={optionList}
-                              placeholderOption="— Select skill —"
-                            />
-                            {row.id && mandatorySubcategorySkillIds.has(row.id) ? (
-                              <LabeledInput
-                                label="Subcategory"
-                                value={row.subcategory}
+                        {rows.map((row, rowIndex) => {
+                          const selectedOtherIds = new Set(
+                            rows
+                              .filter((_, i) => i !== rowIndex)
+                              .map((r) => r.id)
+                              .filter(Boolean),
+                          );
+                          const availableOptions = optionList.filter(
+                            (opt) => opt.value === row.id || !selectedOtherIds.has(opt.value),
+                          );
+                          return (
+                            <div key={`race-everyman-${choiceIndex}-${rowIndex}`} style={{ display: 'grid', gap: 6, gridTemplateColumns: 'minmax(260px, 1fr) minmax(220px, 1fr)' }}>
+                              <RichSelect
+                                label={`Skill ${rowIndex + 1}`}
+                                value={row.id}
                                 onChange={(value) => updateGroupedSkillChoiceRow(setRaceEverymanChoiceRows, choiceIndex, rowIndex, {
-                                  subcategory: value,
+                                  id: value,
+                                  subcategory: '',
                                 })}
-                                placeholder="Enter subcategory"
-                                error={errors.initial && !row.subcategory.trim() ? 'Required' : undefined}
+                                options={availableOptions}
+                                placeholderOption="— Select skill —"
                               />
-                            ) : (
-                              <div />
-                            )}
-                          </div>
-                        ))}
+                              {row.id && mandatorySubcategorySkillIds.has(row.id) ? (
+                                <LabeledInput
+                                  label="Subcategory"
+                                  value={row.subcategory}
+                                  onChange={(value) => updateGroupedSkillChoiceRow(setRaceEverymanChoiceRows, choiceIndex, rowIndex, {
+                                    subcategory: value,
+                                  })}
+                                  placeholder="Enter subcategory"
+                                  error={errors.initial && !row.subcategory.trim() ? 'Required' : undefined}
+                                />
+                              ) : (
+                                <div />
+                              )}
+                            </div>
+                          );
+                        })}
                       </div>
                     );
                   })}
@@ -3605,7 +3626,7 @@ export default function CharacterCreationView() {
                           {categoryNameById.get(def.id) ?? def.id}: select one skill to gain {def.value} rank{def.value === 1 ? '' : 's'}.
                         </div>
                         <div style={{ display: 'grid', gap: 6, gridTemplateColumns: 'minmax(260px, 1fr) minmax(220px, 1fr)' }}>
-                          <LabeledSelect
+                          <RichSelect
                             label="Skill"
                             value={row.id}
                             onChange={(value) => updateFlatSkillChoiceRow(setCultureTypeCategorySkillRankRows, index, {
@@ -3673,7 +3694,7 @@ export default function CharacterCreationView() {
                                 return row.subcategory.trim().length > 0 && !state.hasEmptySubcategory;
                               });
                               return (
-                                <LabeledSelect
+                                <RichSelect
                                   label={`Skill ${rowIndex + 1}`}
                                   value={row.id}
                                   onChange={(value) => updateGroupedSkillChoiceRow(setProfessionSkillDevelopmentChoiceRows, choiceIndex, rowIndex, {
@@ -3749,7 +3770,7 @@ export default function CharacterCreationView() {
                                 return row.subcategory.trim().length > 0 && !state.hasEmptySubcategory;
                               });
                               return (
-                                <LabeledSelect
+                                <RichSelect
                                   label={`Skill ${rowIndex + 1}`}
                                   value={row.id}
                                   onChange={(value) => updateGroupedSkillChoiceRow(setProfessionCategoryDevelopmentChoiceRows, choiceIndex, rowIndex, {
@@ -3825,7 +3846,7 @@ export default function CharacterCreationView() {
                                 return row.subcategory.trim().length > 0 && !state.hasEmptySubcategory;
                               });
                               return (
-                                <LabeledSelect
+                                <RichSelect
                                   label={`Skill ${rowIndex + 1}`}
                                   value={row.id}
                                   onChange={(value) => updateGroupedSkillChoiceRow(setProfessionGroupDevelopmentChoiceRows, choiceIndex, rowIndex, {
@@ -4421,7 +4442,7 @@ export default function CharacterCreationView() {
                   <strong>Skill Bonus</strong>
                   <div style={{ color: 'var(--muted)' }}>Each selected skill grants +10 and costs 1 point.</div>
                   <div style={{ display: 'flex', gap: 8, alignItems: 'end', flexWrap: 'wrap' }}>
-                    <LabeledSelect
+                    <RichSelect
                       label="Add Skill Bonus"
                       hideLabel={true}
                       value=""
@@ -4694,11 +4715,11 @@ export default function CharacterCreationView() {
                                 </div>
                                 <div style={{ display: 'grid', gap: 6 }}>
                                   {allocs.map((alloc, ai) => {
-                                    const availableOpts = skills.filter((s) => optionIds.has(s.id) && (s.id === alloc.id || !usedIds.has(s.id))).map((s) => ({ value: s.id, label: s.name }));
+                                    const availableOpts = skills.filter((s) => optionIds.has(s.id) && (s.id === alloc.id || !usedIds.has(s.id))).map(toSkillRichOption);
                                     return (
                                       <div key={ai} style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}>
                                         <div style={{ flex: 1 }}>
-                                          <LabeledSelect
+                                          <RichSelect
                                             label={`Skill ${ai + 1}`}
                                             value={alloc.id}
                                             onChange={(v) => updateResolution((r) => ({ ...r, skillRankChoices: r.skillRankChoices.map((g, gIdx) => gIdx !== gi ? g : g.map((a, aIdx) => aIdx !== ai ? a : { ...a, id: v, subcategory: '' })) }))}
@@ -4746,11 +4767,11 @@ export default function CharacterCreationView() {
                                 </div>
                                 <div style={{ display: 'grid', gap: 6 }}>
                                   {allocs.map((alloc, ai) => {
-                                    const availableOpts = catSkills.filter((s) => s.id === alloc.id || !usedIds.has(s.id)).map((s) => ({ value: s.id, label: s.name }));
+                                    const availableOpts = catSkills.filter((s) => s.id === alloc.id || !usedIds.has(s.id)).map(toSkillRichOption);
                                     return (
                                       <div key={ai} style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}>
                                         <div style={{ flex: 1 }}>
-                                          <LabeledSelect
+                                          <RichSelect
                                             label={`Skill ${ai + 1}`}
                                             value={alloc.id}
                                             onChange={(v) => updateResolution((r) => ({ ...r, categoryMultiSkillChoices: r.categoryMultiSkillChoices.map((g, gIdx) => gIdx !== gi ? g : g.map((a, aIdx) => aIdx !== ai ? a : { ...a, id: v, subcategory: '' })) }))}
@@ -4798,11 +4819,11 @@ export default function CharacterCreationView() {
                                 </div>
                                 <div style={{ display: 'grid', gap: 6 }}>
                                   {allocs.map((alloc, ai) => {
-                                    const availableOpts = grpSkills.filter((s) => s.id === alloc.id || !usedIds.has(s.id)).map((s) => ({ value: s.id, label: s.name }));
+                                    const availableOpts = grpSkills.filter((s) => s.id === alloc.id || !usedIds.has(s.id)).map(toSkillRichOption);
                                     return (
                                       <div key={ai} style={{ display: 'flex', gap: 6, alignItems: 'flex-end' }}>
                                         <div style={{ flex: 1 }}>
-                                          <LabeledSelect
+                                          <RichSelect
                                             label={`Skill ${ai + 1}`}
                                             value={alloc.id}
                                             onChange={(v) => updateResolution((r) => ({ ...r, groupMultiSkillChoices: r.groupMultiSkillChoices.map((g, gIdx) => gIdx !== gi ? g : g.map((a, aIdx) => aIdx !== ai ? a : { ...a, id: v, subcategory: '' })) }))}
@@ -4839,7 +4860,7 @@ export default function CharacterCreationView() {
                             const grpName = groups.find((g) => g.id === choiceDef.id)?.name ?? choiceDef.id;
                             const isWeaponsGroup = choiceDef.id === 'SKILLGROUP_WEAPON';
                             const catsInGroup = categories.filter((c) => c.group === choiceDef.id).map((c) => ({ value: c.id, label: c.name }));
-                            const skillsInSelectedCat = slot.categoryId ? (skillIdsByCategory.get(slot.categoryId) ?? []).map((s) => ({ value: s.id, label: s.name })) : [];
+                            const skillsInSelectedCat = slot.categoryId ? (skillIdsByCategory.get(slot.categoryId) ?? []).map(toSkillRichOption) : [];
                             const weaponTypeOpts = slot.skillId && isWeaponsGroup ? (weaponTypeOptionsBySkillId.get(slot.skillId) ?? []) : [];
                             return (
                               <div key={gi} style={{ display: 'grid', gap: 6 }}>
@@ -4857,7 +4878,7 @@ export default function CharacterCreationView() {
                                   placeholderOption="— Select category —"
                                 />
                                 {slot.categoryId && (
-                                  <LabeledSelect
+                                  <RichSelect
                                     label="Skill"
                                     value={slot.skillId}
                                     onChange={(v) => updateResolution((r) => ({
@@ -5008,9 +5029,9 @@ export default function CharacterCreationView() {
                                   {Array.from({ length: choiceDef.numChoices }, (_, si) => {
                                     const val = chosen[si] ?? '';
                                     const usedOthers = new Set(chosen.filter((s, i) => i !== si && s));
-                                    const opts = poolSkills.filter((s) => s.id === val || !usedOthers.has(s.id)).map((s) => ({ value: s.id, label: s.name }));
+                                    const opts = poolSkills.filter((s) => s.id === val || !usedOthers.has(s.id)).map(toSkillRichOption);
                                     return (
-                                      <LabeledSelect
+                                      <RichSelect
                                         key={si}
                                         label={`Skill ${si + 1}`}
                                         value={val}

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -633,6 +633,7 @@ export default function CharacterCreationView() {
   const [cultureTypeId, setCultureTypeId] = useState('');
   const [cultureId, setCultureId] = useState('');
   const [professionId, setProfessionId] = useState('');
+  const [showDescriptions, setShowDescriptions] = useState(false);
   const [selectedRealms, setSelectedRealms] = useState<Realm[]>([]);
 
   const [raceEverymanChoiceRows, setRaceEverymanChoiceRows] = useState<SkillChoiceRow[][]>([]);
@@ -1060,6 +1061,7 @@ export default function CharacterCreationView() {
         value: p.id,
         label: isRaceMatched ? `${p.name} (Racial)` : (isPreferred ? `${p.name} (Culture Preferred)` : p.name),
         disabled: isRestricted || isRaceDisallowed,
+        description: p.description,
       };
     });
   }, [professions, preferredProfessions, raceDisallowedProfessionIds, raceMatchedProfessionIds, restrictedProfessions]);
@@ -3331,6 +3333,16 @@ export default function CharacterCreationView() {
           />
         )}
 
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'var(--muted)' }}>
+          <input
+            type="checkbox"
+            id="show-descriptions"
+            checked={showDescriptions}
+            onChange={(e) => setShowDescriptions(e.target.checked)}
+          />
+          <label htmlFor="show-descriptions" style={{ fontSize: 14, cursor: 'pointer' }}>Show descriptions</label>
+        </div>
+
         <div style={{ color: 'var(--muted)' }}>
           Complete each step in order. Progression is locked until the current step is valid.
         </div>
@@ -3472,7 +3484,7 @@ export default function CharacterCreationView() {
                     setSelectedRealms([]);
                     resetBackgroundState();
                   }}
-                  options={professionOptions}
+                  options={professionOptions.map((o) => ({ ...o, title: showDescriptions ? o.description : undefined }))}
                   helperText={
                     culture
                       ? `Preferred: ${culture.preferredProfessions.length}, Restricted: ${culture.restrictedProfessions.length}`

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -997,6 +997,15 @@ export default function CharacterCreationView() {
   }, [spellLists]);
 
   const pureExtraSpellListOptions = useMemo(() => {
+    // Build a map of spellListId → categoryId for Open/Closed categories
+    const spellListCategoryMap = new Map<string, string>();
+    for (const catId of [OWN_REALM_OPEN_LISTS_CATEGORY_ID, OWN_REALM_CLOSED_LISTS_CATEGORY_ID]) {
+      const entry = characterBuilder.categorySpellLists.find((c) => c.category === catId);
+      for (const slId of entry?.spellLists ?? []) {
+        spellListCategoryMap.set(slId, catId);
+      }
+    }
+
     const fromCategories = [OWN_REALM_OPEN_LISTS_CATEGORY_ID, OWN_REALM_CLOSED_LISTS_CATEGORY_ID]
       .flatMap((catId) => {
         const entry = characterBuilder.categorySpellLists.find((c) => c.category === catId);
@@ -1008,9 +1017,15 @@ export default function CharacterCreationView() {
     const currentSelections = (professionBaseSpellListChoiceRows[pureGroupIndex] ?? []).filter(Boolean);
     const allIds = Array.from(new Set([...fromCategories, ...currentSelections]));
     return allIds
-      .map((id) => ({ value: id, label: spellListNameById.get(id) ?? id }))
+      .map((id) => {
+        const catId = spellListCategoryMap.get(id);
+        const rawCatName = catId ? (categoryNameById.get(catId) ?? catId) : undefined;
+        const catName = rawCatName?.replace(/^.*?\s-\s/, '');
+        const slName = spellListNameById.get(id) ?? id;
+        return { value: id, label: catName ? `${slName} — ${catName}` : slName };
+      })
       .sort((a, b) => a.label.localeCompare(b.label));
-  }, [characterBuilder.categorySpellLists, spellListNameById, professionBaseSpellListChoiceDefinitions.length, professionBaseSpellListChoiceRows]);
+  }, [characterBuilder.categorySpellLists, spellListNameById, categoryNameById, professionBaseSpellListChoiceDefinitions.length, professionBaseSpellListChoiceRows]);
 
   const restrictedProfessions = useMemo(
     () => new Set(culture?.restrictedProfessions ?? []),

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -1453,11 +1453,17 @@ export default function CharacterCreationView() {
         return true;
       })
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map((tp) => ({
-        value: tp.id,
-        label: `${tp.name}${tp.lifestyle ? ' (Lifestyle)' : ''} — ${tpCostMap.get(tp.id) ?? '?'} DP`,
-      }));
-  }, [availableTrainingPackages, apprenticeTrainingPackageIds, apprenticeSelectedLifestylePackageId, tpCostMap, apprenticeDpRemaining]);
+      .map((tp): RichSelectOption => {
+        const cost = tpCostMap.get(tp.id) ?? '?';
+        const secondary = tp.lifestyle ? `(Lifestyle) \u2014 ${cost} DP` : `${cost} DP`;
+        return {
+          value: tp.id,
+          label: <RichOptionLabel primary={tp.name} secondary={secondary} />,
+          searchText: `${tp.name} ${secondary}`,
+          title: showDescriptions && tp.description ? tp.description : undefined,
+        };
+      });
+  }, [availableTrainingPackages, apprenticeTrainingPackageIds, apprenticeSelectedLifestylePackageId, tpCostMap, apprenticeDpRemaining, showDescriptions]);
 
   const apprenticeSkillOptions = useMemo(() => {
     const selectedSet = new Set(apprenticeSkillPurchases.map((p) => p.id));
@@ -1470,13 +1476,18 @@ export default function CharacterCreationView() {
         return getSkillMaxDpPurchases(costElements, devType, tpRanks) > 0;
       })
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map((s) => {
+      .map((s): RichSelectOption => {
         const costElements = categoryCostMap.get(s.category) ?? [];
         const devType = skillDevTypeMap.get(s.id);
         const tpRanks = tpGrantedSkillRankCounts.get(s.id) ?? 0;
         const nextRankCost = getSkillDpCostWithTpOffset(costElements, devType, 1, tpRanks);
         const groupLabel = categoryGroupNameById.get(s.category) ?? s.category;
-        return { value: s.id, label: `${s.name} (${groupLabel}) — ${nextRankCost} DP` };
+        const secondary = `(${groupLabel}) \u2014 ${nextRankCost} DP`;
+        return {
+          value: s.id,
+          label: <RichOptionLabel primary={s.name} secondary={secondary} />,
+          searchText: `${s.name} ${secondary}`,
+        };
       });
   }, [skills, apprenticeSkillPurchases, categoryCostMap, skillDevTypeMap, categoryGroupNameById, tpGrantedSkillRankCounts]);
 
@@ -1494,24 +1505,34 @@ export default function CharacterCreationView() {
         const bLabel = categoryNameById.get(b.id) ?? b.id;
         return aLabel.localeCompare(bLabel);
       })
-      .map((c) => {
+      .map((c): RichSelectOption => {
         const costElements = categoryCostMap.get(c.id) ?? [];
         const tpRanks = tpGrantedCategoryRankCounts.get(c.id) ?? 0;
         const nextRankCost = getCategoryDpCostWithTpOffset(costElements, 1, tpRanks);
         const baseLabel = categoryNameById.get(c.id) ?? c.id;
-        return { value: c.id, label: `${baseLabel} — ${nextRankCost} DP` };
+        const secondary = `${nextRankCost} DP`;
+        return {
+          value: c.id,
+          label: <RichOptionLabel primary={baseLabel} secondary={secondary} />,
+          searchText: `${baseLabel} \u2014 ${secondary}`,
+        };
       });
   }, [categories, apprenticeCategoryPurchases, categoryCostMap, categoryNameById, tpGrantedCategoryRankCounts]);
 
   const apprenticeSpellCategoryOptions = useMemo(
     () => characterBuilder.categorySpellLists
-      .map((c) => {
+      .map((c): RichSelectOption => {
         const costElements = categoryCostMap.get(c.category) ?? [];
         const nextRankCost = getCategoryOrSpellListPurchaseTotalCost(costElements, 1);
         const catName = categoryNameById.get(c.category) ?? c.category;
-        return { value: c.category, label: `${catName} — ${nextRankCost} DP / rank` };
+        const secondary = `${nextRankCost} DP / rank`;
+        return {
+          value: c.category,
+          label: <RichOptionLabel primary={catName} secondary={secondary} />,
+          searchText: `${catName} \u2014 ${secondary}`,
+        };
       })
-      .sort((a, b) => a.label.localeCompare(b.label)),
+      .sort((a, b) => (a.searchText ?? '').localeCompare(b.searchText ?? '')),
     [characterBuilder.categorySpellLists, categoryNameById, categoryCostMap],
   );
 
@@ -4604,7 +4625,7 @@ export default function CharacterCreationView() {
                         })}
                       </div>
                     )}
-                    <LabeledSelect
+                    <RichSelect
                       label="Add Training Package"
                       hideLabel={true}
                       value=""
@@ -4612,6 +4633,7 @@ export default function CharacterCreationView() {
                         if (v) setApprenticeTrainingPackageIds((prev) => [...prev, v]);
                       }}
                       options={apprenticeTrainingPackageOptions}
+                      placeholderOption="— Add training package —"
                     />
                   </div>
                   <div>
@@ -5313,7 +5335,7 @@ export default function CharacterCreationView() {
                         })}
                       </div>
                     )}
-                    <LabeledSelect
+                    <RichSelect
                       label="Add Skill"
                       hideLabel={true}
                       value=""
@@ -5323,6 +5345,7 @@ export default function CharacterCreationView() {
                         }
                       }}
                       options={apprenticeSkillOptions}
+                      placeholderOption="— Add skill —"
                     />
                   </div>
 
@@ -5385,7 +5408,7 @@ export default function CharacterCreationView() {
                         })}
                       </div>
                     )}
-                    <LabeledSelect
+                    <RichSelect
                       label="Add Category"
                       value=""
                       hideLabel={true}
@@ -5395,6 +5418,7 @@ export default function CharacterCreationView() {
                         }
                       }}
                       options={apprenticeCategoryOptions}
+                      placeholderOption="— Add category —"
                     />
                   </div>
 
@@ -5460,7 +5484,7 @@ export default function CharacterCreationView() {
                     )}
                     {apprenticeAddingSpellList ? (
                       <div style={{ display: 'grid', gap: 8 }}>
-                        <LabeledSelect
+                        <RichSelect
                           label="Spell Category"
                           hideLabel={true}
                           value={apprenticeSelectedSpellCategory}


### PR DESCRIPTION
This pull request introduces a new, more flexible `RichSelect` component for selecting options with richer labels and improved accessibility, and refactors several parts of the character creation flow to use this new component. The update also enhances the formatting of skill and spell list options by displaying their categories in a muted style, improving clarity for users. Additionally, the codebase is updated to export the new component and to support richer option data structures throughout.

**Key changes:**

### New Component: RichSelect

- Added a new `RichSelect` component in `src/components/inputs/RichSelect.tsx`, supporting rich labels (with primary/secondary text), keyboard navigation, accessibility features, and custom rendering for options. Also includes a `RichOptionLabel` helper for displaying a main label with a muted secondary label (typically the category).
- Exported `RichSelect` from the inputs index, making it available for use throughout the application.

### Refactoring Character Creation to Use RichSelect

- Updated option formatting in `CharacterCreationView.tsx` to use `RichSelectOption` objects, displaying both skill/spell list names and their categories using the new `RichOptionLabel` component. Several `useMemo` hooks now map data to this richer format, improving the user interface and accessibility. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R30-R32) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R946-R1035) [[3]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1010-R1050) [[4]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1166-R1210)
- Added a new state variable `showDescriptions` to `CharacterCreationView.tsx` for future UI enhancements.

### Accessibility and Option Data Improvements

- Enhanced the `LabeledSelectOption` interface to support an optional `title` property for native tooltips, and passed this through to rendered `<option>` elements. [[1]](diffhunk://#diff-e1131a17b5cd88af46adcf6d4c296aad91e97ccba65034130f8b11760de6509fR7) [[2]](diffhunk://#diff-e1131a17b5cd88af46adcf6d4c296aad91e97ccba65034130f8b11760de6509fL84-R85)
- Extended profession options in character creation to include a `description` field, allowing for richer tooltips or descriptions in the UI.

### Codebase Maintenance

- Cleaned up imports and removed now-obsolete option mapping code in `CharacterCreationView.tsx` to support the new rich option format and avoid duplication. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1-R1) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L857-L912)

These changes collectively provide a more user-friendly and accessible selection experience, especially for complex option lists like skills and spell lists, and lay the groundwork for further UI improvements.