### PR TITLE
Add racial resistances

### DIFF
--- a/src/api/race.ts
+++ b/src/api/race.ts
@@ -5,6 +5,7 @@ import type {
   LanguageAbility,
   Race,
   RacesPayload,
+  RaceResistanceBonus,
   RaceSkillRef,
   RaceStatBonus,
   RaceSkillCategoryChoice,
@@ -60,6 +61,13 @@ function statBonusFromJson(x: any): RaceStatBonus {
   };
 }
 
+function resistanceBonusFromJson(x: any): RaceResistanceBonus {
+  return {
+    id: asString(x?.id) as RaceResistanceBonus['id'],
+    value: asInt(x?.value),
+  };
+}
+
 function categoryChoiceFromJson(x: any): RaceSkillCategoryChoice {
   return {
     numChoices: asInt(x?.['num-choices'] ?? x?.numChoices),
@@ -108,6 +116,10 @@ function fromJson(x: any): Race {
 
     statBonuses: Array.isArray(x?.statBonuses)
       ? x.statBonuses.map(statBonusFromJson)
+      : [],
+
+    resistanceBonuses: Array.isArray(x?.resistanceBonuses)
+      ? x.resistanceBonuses.map(resistanceBonusFromJson)
       : [],
 
     everymanSkills: Array.isArray(x?.everymanSkills)

--- a/src/endpoints/race/RaceView.tsx
+++ b/src/endpoints/race/RaceView.tsx
@@ -41,6 +41,7 @@ import type {
 import {
   CREATURE_SIZES, type CreatureSize,
   CRITICAL_TABLE_TYPES, type CriticalTableType,
+  BASE_RESISTANCE_TYPES, type ResistanceType,
   STATS, type Stat,
 } from '../../types/enum';
 
@@ -74,6 +75,11 @@ type SkillBonusVM = {
 
 type StatBonusVM = {
   id: Stat | '';
+  value: string;
+};
+
+type ResistanceBonusVM = {
+  id: ResistanceType | '';
   value: string;
 };
 
@@ -117,6 +123,7 @@ type FormState = {
   adolescentLanguages: LanguageRankVM[];
 
   statBonuses: StatBonusVM[];
+  resistanceBonuses: ResistanceBonusVM[];
 
   everymanSkills: SkillRefVM[];
   restrictedSkills: SkillRefVM[];
@@ -156,6 +163,7 @@ type FormErrors = {
   startingLanguages?: string;
   adolescentLanguages?: string;
   statBonuses?: string;
+  resistanceBonuses?: string;
   everymanSkills?: string;
   restrictedSkills?: string;
   skillBonuses?: string;
@@ -197,7 +205,7 @@ const emptyVM = (): FormState => ({
   adolescentLanguages: [],
 
   statBonuses: [],
-
+  resistanceBonuses: [],
   everymanSkills: [],
   restrictedSkills: [],
 
@@ -254,6 +262,11 @@ const toVM = (x: Race): FormState => ({
   })),
 
   statBonuses: (x.statBonuses ?? []).map((r) => ({
+    id: r.id,
+    value: String(r.value),
+  })),
+
+  resistanceBonuses: (x.resistanceBonuses ?? []).map((r) => ({
     id: r.id,
     value: String(r.value),
   })),
@@ -329,6 +342,11 @@ const fromVM = (vm: FormState): Race => ({
 
   statBonuses: vm.statBonuses.map((r) => ({
     id: r.id as Stat,
+    value: Number(r.value),
+  })),
+
+  resistanceBonuses: vm.resistanceBonuses.map((r) => ({
+    id: r.id as ResistanceType,
     value: Number(r.value),
   })),
 
@@ -495,6 +513,11 @@ export default function RaceView() {
 
   const statOptions = useMemo(
     () => STATS.map((v) => ({ value: v, label: v })),
+    [],
+  );
+
+  const resistanceOptions = useMemo(
+    () => BASE_RESISTANCE_TYPES.map((v) => ({ value: v, label: v })),
     [],
   );
 
@@ -975,6 +998,7 @@ export default function RaceView() {
               showSomatic
             />
 
+
             {/* Stat bonuses */}
             <IdValueListEditor
               title="Stat Bonuses"
@@ -984,6 +1008,18 @@ export default function RaceView() {
               options={statOptions}
               viewing={viewing}
               error={errors.statBonuses}
+              signedValues
+            />
+
+            {/* Resistance bonuses */}
+            <IdValueListEditor
+              title="Resistance Bonuses"
+              addButtonLabel='+ Add resistance bonus'
+              rows={form.resistanceBonuses}
+              onChangeRows={(next) => setForm((s) => ({ ...s, resistanceBonuses: next }))}
+              options={resistanceOptions}
+              viewing={viewing}
+              error={errors.resistanceBonuses}
               signedValues
             />
 

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -174,3 +174,8 @@ export const CRITICAL_SIZES: ReadonlyArray<CriticalSize> = ['A', 'B', 'C', 'D', 
 /** Enum for CriticalTableType */
 export type CriticalTableType = 'Normal' | 'Large Creature Physical' | 'Huge Creature Physical' | 'Large Creature Spell' | 'Huge Creature Spell';
 export const CRITICAL_TABLE_TYPES: ReadonlyArray<CriticalTableType> = ['Normal', 'Large Creature Physical', 'Huge Creature Physical', 'Large Creature Spell', 'Huge Creature Spell'] as const;
+
+/** Enum for resistance types */
+export type ResistanceType = 'Arcane' | 'Channeling' | 'ChannelingEssence' | 'ChannelingMentalism' | 'Cold' | 'Disease' | 'Essence' | 'EssenceMentalism' | 'Fear' | 'Heat' | 'Mentalism' | 'Poison';
+export const RESISTANCE_TYPES: ReadonlyArray<ResistanceType> = ['Arcane', 'Channeling', 'ChannelingEssence', 'ChannelingMentalism', 'Cold', 'Disease', 'Essence', 'EssenceMentalism', 'Fear', 'Heat', 'Mentalism', 'Poison'] as const;
+export const BASE_RESISTANCE_TYPES: ReadonlyArray<ResistanceType> = ['Arcane', 'Channeling', 'Cold', 'Disease', 'Essence', 'Fear', 'Heat', 'Mentalism', 'Poison'] as const;

--- a/src/types/race.ts
+++ b/src/types/race.ts
@@ -1,5 +1,5 @@
 // src/types/race.ts
-import type { CreatureSize, CriticalTableType, Stat } from './enum';
+import type { CreatureSize, CriticalTableType, ResistanceType, Stat } from './enum';
 import type { Named, SkillValue } from './base';
 import type { LanguageAbility } from './language';
 
@@ -12,6 +12,12 @@ export interface RaceStatBonus {
   id: Stat;
   value: number;
 }
+
+export interface RaceResistanceBonus {
+  id: ResistanceType;             // ResistanceType enum
+  value: number;
+}
+
 
 export interface RaceSkillCategoryChoice {
   numChoices: number;
@@ -50,6 +56,7 @@ export interface Race extends Named {
   startingLanguages: LanguageAbility[];
   adolescentLanguages: LanguageAbility[];
 
+  resistanceBonuses: RaceResistanceBonus[];
   statBonuses: RaceStatBonus[];
 
   everymanSkills: RaceSkillRef[];


### PR DESCRIPTION
This pull request adds support for "resistance bonuses" to the race system, allowing races to specify bonuses to various resistance types. The changes include updates to the race data model, API serialization/deserialization, and the race view UI to allow editing these bonuses.

**Data Model Updates:**
- Added a new `RaceResistanceBonus` type and a `resistanceBonuses` field to the `Race` interface to represent resistance bonuses for each race. [[1]](diffhunk://#diff-a0233e6ef9ab66e9e4a0ec2327bd679a5888b142f9c90fbcd53f595ddcd83cc4R16-R21) [[2]](diffhunk://#diff-a0233e6ef9ab66e9e4a0ec2327bd679a5888b142f9c90fbcd53f595ddcd83cc4R59)
- Introduced the `ResistanceType` enum and related constants to define valid resistance types.

**API and Serialization:**
- Updated the API layer (`src/api/race.ts`) to handle serialization and deserialization of `resistanceBonuses` in races, including a new `resistanceBonusFromJson` function. [[1]](diffhunk://#diff-f1699ffe637f06917b2d7d94c8745cc270ec873f047cb4e2afd0bc01ba09f282R8) [[2]](diffhunk://#diff-f1699ffe637f06917b2d7d94c8745cc270ec873f047cb4e2afd0bc01ba09f282R64-R70) [[3]](diffhunk://#diff-f1699ffe637f06917b2d7d94c8745cc270ec873f047cb4e2afd0bc01ba09f282R121-R124)

**UI and Form Handling:**
- Extended the race view form state, errors, and view model to include resistance bonuses. [[1]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6R81-R85) [[2]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6R126) [[3]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6R166) [[4]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6L200-R208) [[5]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6R269-R273) [[6]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6R348-R352)
- Added a UI section for editing resistance bonuses in the race editor, using the new options and validation. [[1]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6R519-R523) [[2]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6R1001) [[3]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6R1014-R1025)

**Type Imports and Consistency:**
- Updated imports across files to include the new types and constants. [[1]](diffhunk://#diff-7dccc89e96e3a2fc50866ba8b7ab6d8b804a3364a152ff44f0c705c5ace230b6R44) [[2]](diffhunk://#diff-a0233e6ef9ab66e9e4a0ec2327bd679a5888b142f9c90fbcd53f595ddcd83cc4L2-R2)

These changes ensure that resistance bonuses are now a first-class part of the race system, editable in the UI and handled throughout the codebase.