### PR TITLE
Update characte builder JSON stats

### DIFF
--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -1727,7 +1727,7 @@ export default function CharacterCreationView() {
           stat: roll.assignedStat,
           temporary: Number(roll.temporary) || 0,
           potential: roll.potential ?? 0,
-          bonus: (race?.statBonuses.find((b) => b.id === roll.assignedStat)?.value ?? 0)
+          racialBonus: (race?.statBonuses.find((b) => b.id === roll.assignedStat)?.value ?? 0)
             + apprenticeStatGains.filter((s) => s === roll.assignedStat).length,
         })),
     }));
@@ -2650,7 +2650,7 @@ export default function CharacterCreationView() {
             stat,
             temporary: Number(assigned.temporary) || 0,
             potential: assigned.potential ?? 0,
-            bonus: (race?.statBonuses.find((b) => b.id === stat)?.value ?? 0)
+            racialBonus: (race?.statBonuses.find((b) => b.id === stat)?.value ?? 0)
               + apprenticeStatGains.filter((s) => s === stat).length,
           };
         });

--- a/src/types/characterbuilder.ts
+++ b/src/types/characterbuilder.ts
@@ -16,7 +16,7 @@ export interface CharacterBuilderStatValue {
   stat: Stat;
   temporary: number;
   potential: number;
-  bonus: number;
+  racialBonus: number;
 }
 
 export interface CharacterBuilderCategoryCost {


### PR DESCRIPTION
This pull request updates the naming of a property related to stat bonuses in the character creation process to improve clarity and consistency. The property previously named `bonus` is now renamed to `racialBonus` throughout the relevant files and logic.

**Refactoring for clarity:**

* Renamed the `bonus` property to `racialBonus` in the `CharacterBuilderStatValue` interface in `src/types/characterbuilder.ts` to better reflect its purpose.
* Updated all usages of the `bonus` property to `racialBonus` in the `CharacterCreationView` component, ensuring the code and data structures are consistent with the new naming. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1730-R1730) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L2653-R2653)