### PR TITLE
Provide feedback when stat buttons disabled

### DIFF
--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -4070,8 +4070,23 @@ export default function CharacterCreationView() {
           {step === 'stats' && (
             <section style={{ display: 'grid', gap: 10 }}>
               <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                <button type="button" onClick={generateAllTemporary}>Generate 10 Temporary Rolls (d100)</button>
-                <button type="button" onClick={getPotentials} disabled={statRollsLocked || generatingStats}>Get potentials</button>
+                <button
+                  type="button"
+                  onClick={generateAllTemporary}
+                  disabled={statRollsLocked}
+                  title={statRollsLocked ? 'Stat rolls are locked. Reset to generate new rolls.' : undefined}
+                >Generate 10 Temporary Rolls (d100)</button>
+                <button
+                  type="button"
+                  onClick={getPotentials}
+                  disabled={statRollsLocked || generatingStats || !raceId || !cultureId || !professionId || selectedRealms.length === 0}
+                  title={
+                    statRollsLocked ? 'Stat rolls are already locked.' :
+                      generatingStats ? 'Generating potentials…' :
+                        (!raceId || !cultureId || !professionId || selectedRealms.length === 0) ? 'Race, culture, profession, and realm must be selected before generating potentials.' :
+                          undefined
+                  }
+                >Get potentials</button>
               </div>
 
               <div style={{ color: 'var(--muted)' }}>


### PR DESCRIPTION
This pull request improves the user experience in the character creation stats step by adding better validation and feedback to the action buttons. The main changes are:

**User interface improvements:**

* The "Generate 10 Temporary Rolls (d100)" button is now disabled when stat rolls are locked, with a tooltip explaining why.
* The "Get potentials" button is now disabled unless all required selections (race, culture, profession, and at least one realm) are made, stat rolls are unlocked, and stats are not currently being generated. The button also provides a context-sensitive tooltip to inform users why it may be disabled.