### PR TITLE
Add PC/NPC selection during character creation

### DIFF
--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -654,6 +654,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: () => v
   const [characterName, setCharacterName] = useState('');
 
   const [isMale, setIsMale] = useState(true);
+  const [isPC, setIsPC] = useState(false);
   const [physiqueAutoHeight, setPhysiqueAutoHeight] = useState(true);
   const [physiqueEnteredHeightStr, setPhysiqueEnteredHeightStr] = useState('');
   const [physiqueAutoBuildMod, setPhysiqueAutoBuildMod] = useState(true);
@@ -1745,6 +1746,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: () => v
       ...prev,
       name: characterName,
       male: isMale,
+      pc: isPC,
       race: raceId,
       culture: cultureId,
       cultureType: cultureTypeId,
@@ -1775,7 +1777,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: () => v
           totalBonus: 0,
         })),
     }));
-  }, [characterName, isMale, raceId, cultureTypeId, cultureId, professionId, selectedRealms, statRolls, race, apprenticeStatGains]);
+  }, [characterName, isMale, isPC, raceId, cultureTypeId, cultureId, professionId, selectedRealms, statRolls, race, apprenticeStatGains]);
 
   useEffect(() => {
     setCharacterBuilder((prev) => ({
@@ -2645,6 +2647,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: () => v
         const response = await setPrimaryDefinition({
           ...characterBuilder,
           name: characterName.trim(),
+          pc: isPC,
           race: raceId,
           culture: cultureId,
           profession: professionId,
@@ -3231,6 +3234,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: () => v
     setStep('primary');
     setCharacterName('');
     setIsMale(true);
+    setIsPC(false);
     setPhysiqueAutoHeight(true);
     setPhysiqueEnteredHeightStr('');
     setPhysiqueAutoBuildMod(true);
@@ -3555,13 +3559,15 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: () => v
           {step === 'primary' && (
             <section style={{ display: 'grid', gap: 12 }}>
               <div style={{ display: 'grid', gap: 10, gridTemplateColumns: '1fr 1fr' }}>
-                <LabeledInput
-                  label="Name"
-                  value={characterName}
-                  onChange={(v) => setCharacterName(v)}
-                  placeholder="Character name"
-                  error={errors.primary && !characterName.trim() ? 'Required' : undefined}
-                />
+                <div style={{ gridColumn: '1 / -1' }}>
+                  <LabeledInput
+                    label="Name"
+                    value={characterName}
+                    onChange={(v) => setCharacterName(v)}
+                    placeholder="Character name"
+                    error={errors.primary && !characterName.trim() ? 'Required' : undefined}
+                  />
+                </div>
 
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 4, justifyContent: 'flex-end', paddingBottom: 2 }}>
                   <span style={{ fontSize: 14, fontWeight: 500 }}>Sex</span>
@@ -3575,6 +3581,22 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: () => v
                       label="Female"
                       checked={!isMale}
                       onChange={(checked) => { if (checked) setIsMale(false); }}
+                    />
+                  </div>
+                </div>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, justifyContent: 'flex-end', paddingBottom: 2 }}>
+                  <span style={{ fontSize: 14, fontWeight: 500 }}>Character Type</span>
+                  <div style={{ display: 'flex', gap: 16 }}>
+                    <CheckboxInput
+                      label="NPC"
+                      checked={!isPC}
+                      onChange={(checked) => { if (checked) setIsPC(false); }}
+                    />
+                    <CheckboxInput
+                      label="PC"
+                      checked={isPC}
+                      onChange={(checked) => { if (checked) setIsPC(true); }}
                     />
                   </div>
                 </div>

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -32,6 +32,7 @@ export interface CharacterCategorySpellLists {
 
 export interface CharacterBuilder extends Named {
   built: boolean;
+  pc: boolean;
   race: string; // Race.id
   culture: string; // Culture.id
   cultureType: string;  // CultureType.id
@@ -125,6 +126,7 @@ export function createEmptyCharacterBuilder(): CharacterBuilder {
     id: '',
     name: '',
     built: false,
+    pc: false,
     race: '',
     culture: '',
     cultureType: '',


### PR DESCRIPTION
This pull request adds support for specifying whether a character is a player character (PC) or a non-player character (NPC) during character creation. It introduces a new `pc` boolean field to the character builder state and updates the UI to allow users to select the character type. The changes ensure that the PC/NPC status is consistently tracked and submitted throughout the character creation process.

**Character type support:**

* Added a new `pc` boolean field to the `CharacterBuilder` interface and initialized it in `createEmptyCharacterBuilder`. [[1]](diffhunk://#diff-fb6199dde00423ad063534d72c7a883f24d767da794e32f61ed3660508280957R35) [[2]](diffhunk://#diff-fb6199dde00423ad063534d72c7a883f24d767da794e32f61ed3660508280957R129)
* Updated the character creation form to include a "Character Type" section with checkboxes for "PC" and "NPC", and wired up the `isPC` state to the UI. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R3562-R3570) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R3588-R3603)
* Ensured the `pc` property is included when updating and submitting the character builder state, so the character type is preserved through the flow. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R1749) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1778-R1780) [[3]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R2650)
* Reset the `isPC` state when restarting character creation to ensure a consistent initial state.
* Added the `isPC` state variable to the component to manage the PC/NPC selection.