### PR TITLE
Fix incorrect finish button handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { ConfirmProvider } from './components/ConfirmDialog';
 import { ToastProvider } from './components/Toast';
 import { ThemeProvider } from './components/ThemeProvider';
@@ -9,6 +9,15 @@ import { splitResources, FALLBACK_RESOURCES, FALLBACK_OBJECTS, type ResourceDef,
 import GenericResourceView from './endpoints/generic/GenericResourceView'; // <-- generic
 
 const CharacterCreationView = lazy(() => import('./endpoints/character/CharacterCreationView'));
+
+function CharacterCreationRoute() {
+  const navigate = useNavigate();
+  return (
+    <Suspense fallback={<div>Loading view…</div>}>
+      <CharacterCreationView onFinish={() => navigate('/characters')} />
+    </Suspense>
+  );
+}
 
 import './layout.css';
 
@@ -123,7 +132,7 @@ function Shell() {
         ) : (
           <Suspense fallback={<div>Loading view…</div>}>
             <Routes>
-              <Route path="/character/create" element={<CharacterCreationView />} />
+              <Route path="/character/create" element={<CharacterCreationRoute />} />
               {/* Object screens */}
               {objects.map((o) => (
                 <Route key={o.path} path={o.path} element={<o.Component />} />


### PR DESCRIPTION
This pull request refactors how the character creation view is loaded and handled in the application, specifically to ensure that after character creation, the user is automatically redirected to the characters list page. The main change is the introduction of a wrapper route component that manages navigation after the character creation process is complete.

Routing and navigation improvements:

* Introduced a new `CharacterCreationRoute` component that wraps `CharacterCreationView` and uses `useNavigate` to redirect users to `/characters` upon completion of character creation (`onFinish`). (`src/App.tsx`, [src/App.tsxR13-R21](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R13-R21))
* Updated the main router to use `CharacterCreationRoute` instead of directly rendering `CharacterCreationView` for the `/character/create` route, enabling the new navigation behavior. (`src/App.tsx`, [src/App.tsxL126-R135](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L126-R135))

Dependency updates:

* Added `useNavigate` to the imports from `react-router-dom` to support programmatic navigation in the new route component. (`src/App.tsx`, [src/App.tsxL2-R2](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2-R2))