### PR TITLE
Auto generate and populate stats

### DIFF
--- a/src/api/characterworkflow.ts
+++ b/src/api/characterworkflow.ts
@@ -16,6 +16,7 @@ export type SetCharacterBackgroundChoicesRequest = {
 const PRIMARY_DEFINITION_ENDPOINT = '/rmce/operations/character/primary-definition';
 const PRIMARY_CHOICES_ENDPOINT = '/rmce/operations/character/primary-choices';
 const STAT_ROLLS_ENDPOINT = '/rmce/operations/character/stat-rolls';
+const AUTO_STATS_ENDPOINT = '/rmce/operations/character/auto-stats';
 const SET_STATS_ENDPOINT = '/rmce/operations/character/set-stats';
 const SET_PHYSIQUE_ENDPOINT = '/rmce/operations/character/set-physique';
 const SET_HOBBY_CHOICES_ENDPOINT = '/rmce/operations/character/set-hobby-choices';
@@ -47,6 +48,12 @@ export async function getStatRollPotentials(
   payload: StatRollRequest[],
 ): Promise<StatRollResponse[]> {
   return sendJson<StatRollResponse[]>(STAT_ROLLS_ENDPOINT, 'POST', payload);
+}
+
+export async function autoCharacterStats(
+  payload: CharacterBuilder,
+): Promise<CharacterBuilder> {
+  return sendJson<CharacterBuilder>(AUTO_STATS_ENDPOINT, 'POST', payload);
 }
 
 export async function setCharacterStats(

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -617,7 +617,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
 
   /** Set of spell list IDs the character already knows (profession base choices + adolescent choice). */
   const knownSpellListIds = useMemo(() => {
-    const ids = new Set<string>(characterBuilder.baseSpellListChoices.filter(Boolean));
+    const ids = new Set<string>((characterBuilder.baseSpellListChoices ?? []).filter(Boolean));
     if (characterBuilder.adolescentSpellListChoice) ids.add(characterBuilder.adolescentSpellListChoice);
     return ids;
   }, [characterBuilder.baseSpellListChoices, characterBuilder.adolescentSpellListChoice]);

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -12,6 +12,7 @@ import {
   fetchSpellLists,
   fetchTrainingPackages,
   fetchWeaponTypes,
+  autoCharacterStats,
   getStatRollPotentials,
   setCharacterStats,
   setCharacterPhysique,
@@ -380,6 +381,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
   const [savingPrimaryDefinition, setSavingPrimaryDefinition] = useState(false);
   const [savingInitialChoices, setSavingInitialChoices] = useState(false);
   const [savingStats, setSavingStats] = useState(false);
+  const [autoingStats, setAutoingStats] = useState(false);
   const [savingHobbyChoices, setSavingHobbyChoices] = useState(false);
   const [savingBackgroundChoices, setSavingBackgroundChoices] = useState(false);
   const [applying, setApplying] = useState(false);
@@ -1877,6 +1879,109 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
     };
   };
 
+  const initHobbyStateFromStatsBuilder = (builderAfterStats: CharacterBuilder) => {
+    const baseSkillByKey = new Map<string, number>();
+    for (const row of builderAfterStats.skillRanks ?? []) {
+      const key = skillChoiceKey(row.id, row.subcategory);
+      baseSkillByKey.set(key, (baseSkillByKey.get(key) ?? 0) + (row.value ?? 0));
+    }
+
+    const baseCategoryById = new Map<string, number>();
+    for (const row of builderAfterStats.categoryRanks ?? []) {
+      baseCategoryById.set(row.id, (baseCategoryById.get(row.id) ?? 0) + (row.value ?? 0));
+    }
+
+    const baseLanguageById = new Map<string, { spoken: number; written: number; somatic: number }>();
+    for (const row of builderAfterStats.languageAbilities ?? []) {
+      baseLanguageById.set(row.language, {
+        spoken: row.spoken ?? 0,
+        written: row.written ?? 0,
+        somatic: row.somatic ?? 0,
+      });
+    }
+
+    const hobbySkillInit = (builderAfterStats.hobbySkillRankChoices ?? []).map((row) => {
+      const key = skillChoiceKey(row.id, row.subcategory);
+      const base = baseSkillByKey.get(key) ?? 0;
+      const max = base + Math.max(0, row.value ?? 0);
+      const prepopulatedSubcategory = row.subcategory?.trim();
+      return {
+        id: row.id,
+        subcategory: prepopulatedSubcategory || undefined,
+        subcategoryLocked: Boolean(prepopulatedSubcategory),
+        base,
+        max,
+        value: base,
+      };
+    });
+
+    const hobbyCategoryInit = (builderAfterStats.hobbyCategoryRankChoices ?? []).map((row) => {
+      const rowId = String(row.id);
+      const base = baseCategoryById.get(rowId) ?? 0;
+      const max = base + Math.max(0, row.value ?? 0);
+      return { id: rowId, base, max, value: base };
+    });
+
+    const hobbyLanguageInit = (race?.adolescentLanguages ?? []).map((row) => {
+      const base = baseLanguageById.get(row.language);
+      const baseSpoken = base?.spoken ?? 0;
+      const baseWritten = base?.written ?? 0;
+      const baseSomatic = base?.somatic ?? 0;
+      const maxSpoken = Math.max(baseSpoken, row.spoken ?? 0);
+      const maxWritten = Math.max(baseWritten, row.written ?? 0);
+      const maxSomatic = Math.max(baseSomatic, row.somatic ?? 0);
+      return {
+        language: row.language,
+        baseSpoken, baseWritten, baseSomatic,
+        maxSpoken, maxWritten, maxSomatic,
+        spoken: baseSpoken, written: baseWritten, somatic: baseSomatic,
+      };
+    });
+
+    const spellListOptions = (
+      builderAfterStats.categorySpellLists
+        .find((row) => row.category === OWN_REALM_OPEN_LISTS_CATEGORY_ID)
+        ?.spellLists ?? []
+    ).map((x) => String(x));
+    const spellListRankBudget = Math.max(
+      0,
+      builderAfterStats.numAdolescentSpellListRanks ?? cultureType?.spellListRanks ?? 0,
+    );
+    const existingSpellListId = spellListRankBudget > 0
+      ? (builderAfterStats.adolescentSpellListChoice ?? '')
+      : '';
+    const spellListSelection = spellListRankBudget > 0
+      ? (spellListOptions.includes(existingSpellListId) ? existingSpellListId : '')
+      : '';
+
+    setHobbyRanksBudget(Math.max(0, builderAfterStats.numHobbySkillRanks ?? cultureType?.hobbySkillRanks ?? 0));
+    setHobbySkillRows(hobbySkillInit);
+    setHobbyCategoryRows(hobbyCategoryInit);
+    setLanguageRanksBudget(Math.max(0, builderAfterStats.numAdolescentLanguageRanks ?? cultureType?.adolescentLanguageRanks ?? 0));
+    setHobbyLanguageRows(hobbyLanguageInit);
+    setSpellListRanksBudget(spellListRankBudget);
+    setHobbySpellListOptions(spellListOptions);
+    setHobbySpellListId(spellListSelection);
+  };
+
+  const handleAutoStats = async () => {
+    if (autoingStats) return;
+    setAutoingStats(true);
+    setSavingStats(true);
+    try {
+      const autoBuilder = await autoCharacterStats(characterBuilder);
+      setCharacterBuilder(autoBuilder);
+      initHobbyStateFromStatsBuilder(autoBuilder);
+      const next = STEP_ORDER[STEP_ORDER.indexOf('stats') + 1];
+      if (next) setStep(next);
+    } catch (e) {
+      toast({ variant: 'danger', title: 'Auto stats failed', description: String(e instanceof Error ? e.message : e) });
+    } finally {
+      setAutoingStats(false);
+      setSavingStats(false);
+    }
+  };
+
   const goNext = async () => {
     const idx = STEP_ORDER.indexOf(step);
     if (idx < 0 || idx >= STEP_ORDER.length - 1) return;
@@ -1971,115 +2076,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
         });
         setCharacterBuilder(statsResponse);
 
-        const builderAfterStats = statsResponse ?? characterBuilder;
-
-        const baseSkillByKey = new Map<string, number>();
-        for (const row of builderAfterStats.skillRanks ?? []) {
-          const key = skillChoiceKey(row.id, row.subcategory);
-          baseSkillByKey.set(key, (baseSkillByKey.get(key) ?? 0) + (row.value ?? 0));
-        }
-
-        const baseCategoryById = new Map<string, number>();
-        for (const row of builderAfterStats.categoryRanks ?? []) {
-          baseCategoryById.set(row.id, (baseCategoryById.get(row.id) ?? 0) + (row.value ?? 0));
-        }
-
-        const baseLanguageById = new Map<string, { spoken: number; written: number; somatic: number }>();
-        for (const row of builderAfterStats.languageAbilities ?? []) {
-          baseLanguageById.set(row.language, {
-            spoken: row.spoken ?? 0,
-            written: row.written ?? 0,
-            somatic: row.somatic ?? 0,
-          });
-        }
-
-        const hobbySkillInit = (builderAfterStats.hobbySkillRankChoices ?? []).map((row) => {
-          const key = skillChoiceKey(row.id, row.subcategory);
-          const base = baseSkillByKey.get(key) ?? 0;
-          const max = base + Math.max(0, row.value ?? 0);
-          const prepopulatedSubcategory = row.subcategory?.trim();
-          return {
-            id: row.id,
-            subcategory: prepopulatedSubcategory || undefined,
-            subcategoryLocked: Boolean(prepopulatedSubcategory),
-            base,
-            max,
-            value: base,
-          };
-        });
-
-        const hobbyCategoryInit = (builderAfterStats.hobbyCategoryRankChoices ?? []).map((row) => {
-          const rowId = String(row.id);
-          const base = baseCategoryById.get(rowId) ?? 0;
-          const max = base + Math.max(0, row.value ?? 0);
-          return {
-            id: rowId,
-            base,
-            max,
-            value: base,
-          };
-        });
-
-        const hobbyLanguageInit = (race?.adolescentLanguages ?? []).map((row) => {
-          const base = baseLanguageById.get(row.language);
-          const baseSpoken = base?.spoken ?? 0;
-          const baseWritten = base?.written ?? 0;
-          const baseSomatic = base?.somatic ?? 0;
-          const maxSpoken = Math.max(baseSpoken, row.spoken ?? 0);
-          const maxWritten = Math.max(baseWritten, row.written ?? 0);
-          const maxSomatic = Math.max(baseSomatic, row.somatic ?? 0);
-          return {
-            language: row.language,
-            baseSpoken,
-            baseWritten,
-            baseSomatic,
-            maxSpoken,
-            maxWritten,
-            maxSomatic,
-            spoken: baseSpoken,
-            written: baseWritten,
-            somatic: baseSomatic,
-          };
-        });
-
-        const spellListOptions = (
-          builderAfterStats.categorySpellLists
-            .find((row) => row.category === OWN_REALM_OPEN_LISTS_CATEGORY_ID)
-            ?.spellLists ?? []
-        ).map((x) => String(x));
-        const spellListRankBudget = Math.max(
-          0,
-          builderAfterStats.numAdolescentSpellListRanks
-          ?? cultureType?.spellListRanks
-          ?? 0,
-        );
-        const existingSpellListId = spellListRankBudget > 0
-          ? (builderAfterStats.adolescentSpellListChoice ?? '')
-          : '';
-        const spellListSelection = spellListRankBudget > 0
-          ? (spellListOptions.includes(existingSpellListId) ? existingSpellListId : '')
-          : '';
-
-        setHobbyRanksBudget(Math.max(
-          0,
-          builderAfterStats.numHobbySkillRanks
-          ?? cultureType?.hobbySkillRanks
-          ?? 0,
-        ));
-        setHobbySkillRows(hobbySkillInit);
-        setHobbyCategoryRows(hobbyCategoryInit);
-
-        setLanguageRanksBudget(Math.max(
-          0,
-          builderAfterStats.numAdolescentLanguageRanks
-          ?? cultureType?.adolescentLanguageRanks
-          ?? 0,
-        ));
-        setHobbyLanguageRows(hobbyLanguageInit);
-
-        setSpellListRanksBudget(spellListRankBudget);
-        setHobbySpellListOptions(spellListOptions);
-        setHobbySpellListId(spellListSelection);
+        initHobbyStateFromStatsBuilder(statsResponse ?? characterBuilder);
       } catch (e) {
         toast({
           variant: 'danger',
@@ -3868,6 +3865,11 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
           {step !== 'summary' && (<>
             <div style={{ display: 'flex', gap: 8 }}>
               <button type="button" onClick={goPrev} disabled={step === 'primary'}>Back</button>
+              {step === 'stats' && (
+                <button type="button" onClick={handleAutoStats} disabled={autoingStats || savingStats}>
+                  {autoingStats ? 'Auto…' : 'Auto'}
+                </button>
+              )}
               <button type="button" onClick={goNext} disabled={!canGoNext || savingPrimaryDefinition || savingInitialChoices || savingStats || savingPhysique || savingHobbyChoices || savingBackgroundChoices}>Next</button>
             </div>
           </>)}

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -34,7 +34,7 @@ export const SPELL_TYPES: ReadonlyArray<SpellType> = ['Base', 'Closed', 'Open', 
 /** Enum for stats */
 export type Stat = 'Agility' | 'Constitution' | 'Empathy' | 'Intuition' | 'Memory' | 'Presence' | 'Quickness' | 'Reasoning' | 'Self Discipline' | 'Strength';
 export const STATS: ReadonlyArray<Stat> = ['Agility', 'Constitution', 'Empathy', 'Intuition', 'Memory', 'Presence', 'Quickness', 'Reasoning', 'Self Discipline', 'Strength'] as const;
-export const DEVELOPMENT_STATS: ReadonlyArray<Stat> = ['Agility', 'Constitution', 'Empathy', 'Intuition', 'Memory'] as const;
+export const DEVELOPMENT_STATS: ReadonlyArray<Stat> = ['Agility', 'Constitution', 'Memory', 'Reasoning', 'Self Discipline'] as const;
 export const REALM_STATS: ReadonlyArray<Stat> = ['Empathy', 'Intuition', 'Presence'] as const;
 
 export function getRealmForStat(stat: Stat): Realm | undefined {


### PR DESCRIPTION
This pull request adds an "Auto" button to the character creation view, allowing users to automatically generate character stats in one click. It introduces a new API endpoint and refactors the code for initializing hobby state after stats are set, improving maintainability and user experience. There is also a fix to the list of development stats.

**New feature: Auto-generate character stats**

* Added `autoCharacterStats` API function and new endpoint `/rmce/operations/character/auto-stats` to support auto-generation of character stats. (`src/api/characterworkflow.ts`) [[1]](diffhunk://#diff-0f4522a4c85f1b8a61d42825272cd14449257f189427df2c9844922558d60cd8R19) [[2]](diffhunk://#diff-0f4522a4c85f1b8a61d42825272cd14449257f189427df2c9844922558d60cd8R53-R58)
* Integrated an "Auto" button into the stats step of the character creation UI, with loading state and error handling. (`src/endpoints/character/CharacterCreationView.tsx`) [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R384) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R3868-R3872) [[3]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R1882-R1984)

**Refactoring and code quality improvements**

* Extracted and reused hobby state initialization logic after stats are set, reducing code duplication and improving maintainability. (`src/endpoints/character/CharacterCreationView.tsx`) [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R1882-R1984) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L1974-R2079)
* Fixed a potential bug by making sure `baseSpellListChoices` is always an array before filtering. (`src/endpoints/character/CharacterCreationView.tsx`)

**Data correction**

* Corrected the `DEVELOPMENT_STATS` constant to include the proper stats. (`src/types/enum.ts`)