### PR TITLE
Add autoBuilder key used by REST server

### DIFF
--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -32,6 +32,7 @@ export interface CharacterCategorySpellLists {
 }
 
 export interface CharacterBuilder extends Named {
+  autoBuilder: string;
   built: boolean;
   pc: boolean;
   race: string; // Race.id
@@ -123,6 +124,7 @@ export function createEmptyCharacterBuilder(): CharacterBuilder {
   return {
     id: '',
     name: '',
+    autoBuilder: '',
     built: false,
     pc: false,
     race: '',


### PR DESCRIPTION
Add a new key to the CharacterBuilder JSON file. This key is used by the REST server and not by the UI so its value needs to be retained and passed during API calls unchanged.