### PR TITLE
Add traits to character choices to assist AI decisions

### DIFF
--- a/src/api/characterworkflow.ts
+++ b/src/api/characterworkflow.ts
@@ -16,7 +16,6 @@ export type SetCharacterBackgroundChoicesRequest = {
 const PRIMARY_DEFINITION_ENDPOINT = '/rmce/operations/character/primary-definition';
 const PRIMARY_CHOICES_ENDPOINT = '/rmce/operations/character/primary-choices';
 const STAT_ROLLS_ENDPOINT = '/rmce/operations/character/stat-rolls';
-const AUTO_STATS_ENDPOINT = '/rmce/operations/character/auto-stats';
 const SET_STATS_ENDPOINT = '/rmce/operations/character/set-stats';
 const SET_PHYSIQUE_ENDPOINT = '/rmce/operations/character/set-physique';
 const SET_HOBBY_CHOICES_ENDPOINT = '/rmce/operations/character/set-hobby-choices';
@@ -48,12 +47,6 @@ export async function getStatRollPotentials(
   payload: StatRollRequest[],
 ): Promise<StatRollResponse[]> {
   return sendJson<StatRollResponse[]>(STAT_ROLLS_ENDPOINT, 'POST', payload);
-}
-
-export async function autoCharacterStats(
-  payload: CharacterBuilder,
-): Promise<CharacterBuilder> {
-  return sendJson<CharacterBuilder>(AUTO_STATS_ENDPOINT, 'POST', payload);
 }
 
 export async function setCharacterStats(

--- a/src/api/profession.ts
+++ b/src/api/profession.ts
@@ -15,6 +15,7 @@ import type {
   SkillDevelopmentTypeValue,
   SkillValue,
 } from '../types';
+import type { CharacterTraits } from '../types/base';
 
 const BASE = '/rmce/data/profession';
 
@@ -25,6 +26,22 @@ const asInt = (v: unknown) => {
 };
 const asStringArray = (v: unknown): string[] =>
   Array.isArray(v) ? v.map((x) => String(x ?? '')).filter(Boolean) : [];
+
+const asTraitInt = (v: unknown): number => {
+  const n = parseInt(String(v ?? ''), 10);
+  return Number.isFinite(n) ? Math.min(9, Math.max(1, n)) : 5;
+};
+function traitsFromJson(t: unknown): CharacterTraits {
+  const x = (t && typeof t === 'object') ? t as Record<string, unknown> : {};
+  return {
+    caster: asTraitInt(x['caster']),
+    combat: asTraitInt(x['combat']),
+    information: asTraitInt(x['information']),
+    stealth: asTraitInt(x['stealth']),
+    support: asTraitInt(x['support']),
+    utility: asTraitInt(x['utility']),
+  };
+}
 
 function spellListChoiceFromJson(x: any): ProfessionSpellListChoice {
   return {
@@ -178,6 +195,7 @@ function fromJson(x: any): Profession {
     skillCategoryCosts: Array.isArray(x?.skillCategoryCosts)
       ? x.skillCategoryCosts.map(skillCategoryCostFromJson)
       : [],
+    traits: traitsFromJson(x?.traits),
   };
 }
 

--- a/src/api/skill.ts
+++ b/src/api/skill.ts
@@ -3,6 +3,7 @@ import { fetchJson, sendJson } from './client';
 import type {
   Skill, SkillsPayload,
 } from '../types';
+import type { CharacterTraits } from '../types/base';
 
 const BASE = '/rmce/data/skill';
 
@@ -12,9 +13,25 @@ const asFloat = (v: unknown) => {
   const n = Number(v);
   return Number.isFinite(n) ? n : NaN;
 };
+const asTraitInt = (v: unknown): number => {
+  const n = parseInt(String(v ?? ''), 10);
+  return Number.isFinite(n) ? Math.min(9, Math.max(1, n)) : 5;
+};
 
 function asStringArray(v: unknown): string[] {
   return Array.isArray(v) ? v.map(x => String(x ?? '')).filter(s => s.length > 0) : [];
+}
+
+function traitsFromJson(t: unknown): CharacterTraits {
+  const x = (t && typeof t === 'object') ? t as Record<string, unknown> : {};
+  return {
+    caster: asTraitInt(x['caster']),
+    combat: asTraitInt(x['combat']),
+    information: asTraitInt(x['information']),
+    stealth: asTraitInt(x['stealth']),
+    support: asTraitInt(x['support']),
+    utility: asTraitInt(x['utility']),
+  };
 }
 
 export async function fetchSkills(): Promise<Skill[]> {
@@ -38,6 +55,7 @@ export async function fetchSkills(): Promise<Skill[]> {
     stats: asStringArray(x.stats) as Skill['stats'],
     exhaustion: asFloat(x.exhaustion),
     distanceMultiplier: asFloat(x.distanceMultiplier),
+    traits: traitsFromJson(x.traits),
   }));
 }
 

--- a/src/api/skillcategory.ts
+++ b/src/api/skillcategory.ts
@@ -3,6 +3,7 @@ import { fetchJson, sendJson } from './client';
 import type {
   SkillCategory, SkillCategoriesPayload,
 } from '../types';
+import type { CharacterTraits } from '../types/base';
 
 import {
   STATS, type Stat,
@@ -13,6 +14,22 @@ const BASE = '/rmce/data/skillcategory';
 const asString = (v: unknown) => String(v ?? '');
 const asBool = (v: unknown) => v === true || v === 'true' || v === 1 || v === '1';
 const STAT_SET = new Set<Stat>(STATS);
+const asTraitInt = (v: unknown): number => {
+  const n = parseInt(String(v ?? ''), 10);
+  return Number.isFinite(n) ? Math.min(9, Math.max(1, n)) : 5;
+};
+
+function traitsFromJson(t: unknown): CharacterTraits {
+  const x = (t && typeof t === 'object') ? t as Record<string, unknown> : {};
+  return {
+    caster: asTraitInt(x['caster']),
+    combat: asTraitInt(x['combat']),
+    information: asTraitInt(x['information']),
+    stealth: asTraitInt(x['stealth']),
+    support: asTraitInt(x['support']),
+    utility: asTraitInt(x['utility']),
+  };
+}
 
 /** Preserve order & duplicates but filter to known Stat values */
 function asStatArray(v: unknown): Stat[] {
@@ -39,6 +56,7 @@ export async function fetchSkillCategories(): Promise<SkillCategory[]> {
     skillProgression: asString(x.skillProgression),
     categoryProgression: asString(x.categoryProgression),
     stats: asStatArray((x as any).stats),
+    traits: traitsFromJson((x as any).traits),
   }));
 }
 

--- a/src/api/spelllist.ts
+++ b/src/api/spelllist.ts
@@ -3,6 +3,7 @@ import { fetchJson, sendJson } from './client';
 import type {
   SpellList, SpellListsPayload,
 } from '../types';
+import type { CharacterTraits } from '../types/base';
 
 import {
   SPELL_TYPES, SpellType,
@@ -26,6 +27,21 @@ function asRealmArray(v: unknown): Realm[] {
 function asBool(v: unknown): boolean {
   return v === true || v === 'true' || v === 1 || v === '1';
 }
+const asTraitInt = (v: unknown): number => {
+  const n = parseInt(String(v ?? ''), 10);
+  return Number.isFinite(n) ? Math.min(9, Math.max(1, n)) : 5;
+};
+function traitsFromJson(t: unknown): CharacterTraits {
+  const x = (t && typeof t === 'object') ? t as Record<string, unknown> : {};
+  return {
+    caster: asTraitInt(x['caster']),
+    combat: asTraitInt(x['combat']),
+    information: asTraitInt(x['information']),
+    stealth: asTraitInt(x['stealth']),
+    support: asTraitInt(x['support']),
+    utility: asTraitInt(x['utility']),
+  };
+}
 
 /** GET /rmce/data/spelllist → { spelllists: SpellList[] } */
 export async function fetchSpellLists(): Promise<SpellList[]> {
@@ -38,9 +54,12 @@ export async function fetchSpellLists(): Promise<SpellList[]> {
     name: String(s.name),
     book: String(s.book ?? ''),
     type: asSpellType(s.type),
+    description: String(s.description ?? ''),
     evil: asBool(s.evil),
     summoning: asBool(s.summoning),
+    directed: asBool(s.directed),
     realms: asRealmArray(s.realms),
+    traits: traitsFromJson(s.traits),
   }));
 }
 

--- a/src/api/trainingpackage.ts
+++ b/src/api/trainingpackage.ts
@@ -3,6 +3,7 @@ import { fetchJson, sendJson } from './client';
 import type {
   TrainingPackage, TrainingPackagesPayload,
 } from '../types';
+import type { CharacterTraits } from '../types/base';
 
 const BASE = '/rmce/data/trainingpackage';
 
@@ -14,13 +15,32 @@ const asInt = (v: unknown) => {
 const asBool = (v: unknown) => v === true || v === 'true' || v === 1 || v === '1';
 const asStringArray = (v: unknown): string[] =>
   Array.isArray(v) ? v.map((x) => String(x ?? '')).filter(Boolean) : [];
+const asTraitInt = (v: unknown): number => {
+  const n = parseInt(String(v ?? ''), 10);
+  return Number.isFinite(n) ? Math.min(9, Math.max(1, n)) : 5;
+};
+
+function traitsFromJson(t: unknown): CharacterTraits {
+  const x = (t && typeof t === 'object') ? t as Record<string, unknown> : {};
+  return {
+    caster: asTraitInt(x['caster']),
+    combat: asTraitInt(x['combat']),
+    information: asTraitInt(x['information']),
+    stealth: asTraitInt(x['stealth']),
+    support: asTraitInt(x['support']),
+    utility: asTraitInt(x['utility']),
+  };
+}
 
 export async function fetchTrainingPackages(): Promise<TrainingPackage[]> {
   const data = await fetchJson<TrainingPackagesPayload>(BASE);
   if (!data || !Array.isArray((data as any).trainingpackages)) {
     throw new Error('Unexpected response: expected { trainingpackages: [...] }');
   }
-  return data.trainingpackages as TrainingPackage[];
+  return data.trainingpackages.map((x: any) => ({
+    ...x,
+    traits: traitsFromJson(x.traits),
+  })) as TrainingPackage[];
 }
 
 export async function upsertTrainingPackage(

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -51,6 +51,27 @@ function clearWidths(persistKey?: string) {
   } catch { }
 }
 
+function loadSort(persistKey?: string): SortState | null {
+  if (!persistKey) return null;
+  try {
+    const s = localStorage.getItem(`${persistKey}:sort`);
+    return s ? (JSON.parse(s) as SortState) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveSort(persistKey: string | undefined, sort: SortState | null) {
+  if (!persistKey) return;
+  try {
+    if (sort) {
+      localStorage.setItem(`${persistKey}:sort`, JSON.stringify(sort));
+    } else {
+      localStorage.removeItem(`${persistKey}:sort`);
+    }
+  } catch { }
+}
+
 export interface DataTableHandle {
   /** Clears persisted column widths and resets the current rendered widths. */
   resetColumnWidths: () => void;
@@ -280,7 +301,7 @@ const DataTableInner = <T,>(
   };
 
   // ---------- Controlled/uncontrolled sort ----------
-  const [innerSort, setInnerSort] = useState<SortState | null>(initialSort);
+  const [innerSort, setInnerSort] = useState<SortState | null>(() => loadSort(persistKey) ?? initialSort);
   const sortState = sortProp !== undefined ? sortProp : innerSort;
 
   // ---------- Filter ----------
@@ -380,7 +401,12 @@ const DataTableInner = <T,>(
       return { colId: col.id, dir: sortState.dir === 'asc' ? 'desc' : 'asc' as SortDir };
     })();
 
-    onSortChange ? onSortChange(next) : setInnerSort(next);
+    if (onSortChange) {
+      onSortChange(next);
+    } else {
+      setInnerSort(next);
+      saveSort(persistKey, next);
+    }
   };
 
   // ---------- Column resizing state ----------

--- a/src/components/inputs/CharacterTraitsEditor.tsx
+++ b/src/components/inputs/CharacterTraitsEditor.tsx
@@ -1,0 +1,84 @@
+import { useId } from 'react';
+import type { CharacterTraits } from '../../types/base';
+
+export interface CharacterTraitsEditorProps {
+  value: CharacterTraits;
+  onChange: (next: CharacterTraits) => void;
+  disabled?: boolean;
+  error?: string | undefined;
+}
+
+type TraitKey = keyof CharacterTraits;
+
+const TRAIT_META: { key: TraitKey; label: string; tooltip: string }[] = [
+  {
+    key: 'caster',
+    label: 'Caster',
+    tooltip: 'The extent to which this resource relates to or requires the use of magic',
+  },
+  {
+    key: 'combat',
+    label: 'Combat',
+    tooltip: 'The extent to which this resource relates to combat or offensive actions',
+  },
+  {
+    key: 'information',
+    label: 'Information',
+    tooltip: 'The extent to which this resource relates to information gathering or knowledge',
+  },
+  {
+    key: 'stealth',
+    label: 'Stealth',
+    tooltip: 'The extent to which this resource relates to being undetected or actions that are best performed while undetected',
+  },
+  {
+    key: 'support',
+    label: 'Support',
+    tooltip: 'The extent to which this resource aids other party members either in or out of combat without directly impacting enemies',
+  },
+  {
+    key: 'utility',
+    label: 'Utility',
+    tooltip: 'The extent to which this, typically active, resource manipulates the state of the world to assist the party',
+  },
+];
+
+export function CharacterTraitsEditor({ value, onChange, disabled = false, error }: CharacterTraitsEditorProps) {
+  const baseId = useId();
+
+  const handleChange = (key: TraitKey, raw: string) => {
+    const n = parseInt(raw, 10);
+    const clamped = Number.isFinite(n) ? Math.min(9, Math.max(1, n)) : value[key];
+    onChange({ ...value, [key]: clamped });
+  };
+
+  return (
+    <fieldset style={{ border: '1px solid var(--border)', borderRadius: 6, padding: '8px 12px', margin: 0 }}>
+      <legend style={{ fontSize: 13, fontWeight: 600, padding: '0 4px' }}>Character Traits</legend>
+      <div style={{ display: 'grid', gridTemplateColumns: `repeat(${TRAIT_META.length}, auto)`, gap: '8px 16px', alignItems: 'start' }}>
+        {TRAIT_META.map(({ key, label, tooltip }) => {
+          const inputId = `${baseId}-${key}`;
+          return (
+            <div key={key} title={tooltip} style={{ display: 'grid', gap: 4 }}>
+              <label htmlFor={inputId} style={{ fontSize: 13, whiteSpace: 'nowrap' }}>{label}</label>
+              <input
+                id={inputId}
+                type="number"
+                min={1}
+                max={9}
+                step={1}
+                value={value[key]}
+                onChange={(e) => handleChange(key, e.target.value)}
+                disabled={disabled}
+                aria-label={label}
+                title={tooltip}
+                style={{ width: 56, padding: '4px 6px', textAlign: 'center' }}
+              />
+            </div>
+          );
+        })}
+      </div>
+      {error && <div style={{ color: '#b00020', marginTop: 6, fontSize: 13 }}>{error}</div>}
+    </fieldset>
+  );
+}

--- a/src/components/inputs/CheckboxGroup.tsx
+++ b/src/components/inputs/CheckboxGroup.tsx
@@ -6,7 +6,7 @@ export type CheckboxOption<T extends string = string> =
 
 export interface CheckboxGroupProps<T extends string = string> {
   /** Visible label for the group (rendered as <legend>) */
-  label: string;
+  label?: string;
 
   /** Selected values */
   value: readonly T[];
@@ -77,12 +77,12 @@ export function CheckboxGroup<T extends string = string>({
   const groupName = name ?? `${groupId}-name`;
 
   type Normalized<T extends string> = { label: string; value: T; disabled?: boolean | undefined };
- 
+
   const normalized: Normalized<T>[] = options.map(opt => {
-  if (typeof opt === 'string') return { label: opt, value: opt };
-  return (typeof opt.disabled === 'boolean')
-    ? { label: opt.label, value: opt.value, disabled: opt.disabled }
-    : { label: opt.label, value: opt.value };
+    if (typeof opt === 'string') return { label: opt, value: opt };
+    return (typeof opt.disabled === 'boolean')
+      ? { label: opt.label, value: opt.value, disabled: opt.disabled }
+      : { label: opt.label, value: opt.value };
   });
 
   const toggle = (v: T) => {
@@ -107,8 +107,8 @@ export function CheckboxGroup<T extends string = string>({
     direction === 'column'
       ? { display: 'grid', gap: 8 }
       : inline
-      ? { display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }
-      : {
+        ? { display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }
+        : {
           display: 'grid',
           gridTemplateColumns: `repeat(${Math.max(1, columns ?? 3)}, minmax(0, 1fr))`,
           gap: 10,
@@ -124,10 +124,11 @@ export function CheckboxGroup<T extends string = string>({
       disabled={disabled}
       style={{ margin: 0, padding: 0, border: 'none', minInlineSize: 0, opacity: disabled ? 0.75 : 1, }}
     >
-      <legend style={{ fontSize: 14, marginBottom: 6 }}>
-        {label}{required ? ' *' : ''}
-      </legend>
-
+      {label && (
+        <legend style={{ fontSize: 14, marginBottom: 6 }}>
+          {label}{required ? ' *' : ''}
+        </legend>
+      )}
 
       {showSelectAll && !disabled && (
         <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>

--- a/src/components/inputs/index.ts
+++ b/src/components/inputs/index.ts
@@ -1,4 +1,5 @@
 export * from './AttackTableEditor';
+export * from './CharacterTraitsEditor';
 export * from './CheckboxGroup';
 export * from './CheckboxInput';
 export * from './ChoiceListEditor';

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -377,6 +377,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
   const [createdCharacter, setCreatedCharacter] = useState<Character | null>(null);
   const [savingPrimaryDefinition, setSavingPrimaryDefinition] = useState(false);
   const [savingInitialChoices, setSavingInitialChoices] = useState(false);
+  const [autoingInitialChoices, setAutoingInitialChoices] = useState(false);
   const [savingStats, setSavingStats] = useState(false);
   const [autoingStats, setAutoingStats] = useState(false);
   const [savingHobbyChoices, setSavingHobbyChoices] = useState(false);
@@ -1961,6 +1962,23 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
     setSpellListRanksBudget(spellListRankBudget);
     setHobbySpellListOptions(spellListOptions);
     setHobbySpellListId(spellListSelection);
+  };
+
+  const handleAutoInitialChoices = async () => {
+    if (autoingInitialChoices) return;
+    setAutoingInitialChoices(true);
+    setSavingInitialChoices(true);
+    try {
+      const response = await setCharacterPrimaryChoices({ ...characterBuilder, autoBuild: true });
+      setCharacterBuilder(response);
+      const next = STEP_ORDER[STEP_ORDER.indexOf('initial') + 1];
+      if (next) setStep(next);
+    } catch (e) {
+      toast({ variant: 'danger', title: 'Auto initial choices failed', description: String(e instanceof Error ? e.message : e) });
+    } finally {
+      setAutoingInitialChoices(false);
+      setSavingInitialChoices(false);
+    }
   };
 
   const handleAutoStats = async () => {
@@ -3864,6 +3882,11 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
           {step !== 'summary' && (<>
             <div style={{ display: 'flex', gap: 8 }}>
               <button type="button" onClick={goPrev} disabled={step === 'primary'}>Back</button>
+              {step === 'initial' && (
+                <button type="button" onClick={handleAutoInitialChoices} disabled={autoingInitialChoices || savingInitialChoices}>
+                  {autoingInitialChoices ? 'Auto…' : 'Auto'}
+                </button>
+              )}
               {step === 'stats' && (
                 <button type="button" onClick={handleAutoStats} disabled={autoingStats || savingStats}>
                   {autoingStats ? 'Auto…' : 'Auto'}

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -10,7 +10,6 @@ import {
   fetchSkillGroups,
   fetchSkills,
   fetchSpellLists,
-  fetchTrainingPackages,
   fetchWeaponTypes,
   autoCharacterStats,
   getStatRollPotentials,
@@ -48,7 +47,6 @@ import type {
   SkillCategory,
   SkillGroup,
   SpellList,
-  TrainingPackage,
   WeaponType,
 } from '../../types';
 

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -11,7 +11,6 @@ import {
   fetchSkills,
   fetchSpellLists,
   fetchWeaponTypes,
-  autoCharacterStats,
   getStatRollPotentials,
   setCharacterStats,
   setCharacterPhysique,
@@ -1969,7 +1968,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
     setAutoingStats(true);
     setSavingStats(true);
     try {
-      const autoBuilder = await autoCharacterStats(characterBuilder);
+      const autoBuilder = await setCharacterStats({ ...characterBuilder, autoBuild: true });
       setCharacterBuilder(autoBuilder);
       initHobbyStateFromStatsBuilder(autoBuilder);
       const next = STEP_ORDER[STEP_ORDER.indexOf('stats') + 1];

--- a/src/endpoints/profession/ProfessionView.tsx
+++ b/src/endpoints/profession/ProfessionView.tsx
@@ -12,6 +12,7 @@ import {
 
 import {
   DataTable, type DataTableHandle, DataTableSearchInput, type ColumnDef,
+  CharacterTraitsEditor,
   CheckboxGroup,
   CheckboxInput,
   ChoiceListEditor,
@@ -46,6 +47,7 @@ import type {
   SkillValue,
   SpellList,
 } from '../../types';
+import type { CharacterTraits } from '../../types/base';
 
 import {
   REALMS, type Realm,
@@ -105,6 +107,7 @@ type FormState = {
   skillGroupSkillDevelopmentTypeChoices: IdChoiceVM[];
 
   skillCategoryCosts: CategoryCostVM[];
+  traits: CharacterTraits;
 };
 
 type FormErrors = {
@@ -157,6 +160,7 @@ const emptyVM = (): FormState => ({
   skillGroupSkillDevelopmentTypeChoices: [],
 
   skillCategoryCosts: [],
+  traits: { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 },
 });
 
 // ---------- VM converters ----------
@@ -213,6 +217,7 @@ const toVM = (x: Profession): FormState => ({
     category: r.category,
     cost: r.cost,
   })),
+  traits: x.traits ?? { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 },
 });
 
 const fromVM = (vm: FormState): Profession => ({
@@ -290,6 +295,7 @@ const fromVM = (vm: FormState): Profession => ({
     category: r.category,
     cost: r.cost,
   })),
+  traits: vm.traits,
 });
 
 /* ------------------------------------------------------------------ */
@@ -316,6 +322,7 @@ export default function ProfessionView() {
   const [query, setQuery] = useState('');
   const [spellUserTypeFilter, setSpellUserTypeFilter] = useState<SpellUserType | ''>('');
   const [realmFilters, setRealmFilters] = useState<Realm[]>([]);
+  const [traitFilters, setTraitFilters] = useState<Partial<Record<keyof CharacterTraits, number>>>({});
   const [showDescriptionTooltip, setShowDescriptionTooltip] = useState<boolean>(() => {
     try {
       const raw = localStorage.getItem(showDescriptionTooltipStorageKey);
@@ -626,15 +633,20 @@ export default function ProfessionView() {
     return rows.filter((r) => {
       const matchesSpellUserType = !spellUserTypeFilter || r.spellUserType === spellUserTypeFilter;
       const matchesRealms = realmFilters.length === 0 || realmFilters.every((realm) => r.realms.includes(realm));
-      return matchesSpellUserType && matchesRealms;
+      if (!matchesSpellUserType || !matchesRealms) return false;
+      for (const [key, min] of Object.entries(traitFilters) as [keyof CharacterTraits, number][]) {
+        if (min !== undefined && r.traits[key] < min) return false;
+      }
+      return true;
     });
-  }, [rows, spellUserTypeFilter, realmFilters]);
+  }, [rows, spellUserTypeFilter, realmFilters, traitFilters]);
 
-  const hasActiveFilters = spellUserTypeFilter !== '' || realmFilters.length > 0;
+  const hasActiveTraitFilters = Object.keys(traitFilters).length > 0;
+  const hasActiveFilters = spellUserTypeFilter !== '' || realmFilters.length > 0 || hasActiveTraitFilters;
 
   useEffect(() => {
     setPage(1);
-  }, [spellUserTypeFilter, realmFilters]);
+  }, [spellUserTypeFilter, realmFilters, traitFilters]);
 
   useEffect(() => {
     try {
@@ -856,6 +868,7 @@ export default function ProfessionView() {
                 onClick={() => {
                   setSpellUserTypeFilter('');
                   setRealmFilters([]);
+                  setTraitFilters({});
                 }}
               >
                 Clear filters
@@ -867,16 +880,57 @@ export default function ProfessionView() {
             <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
           </div>
 
-          <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 12 }}>
-            <CheckboxGroup<Realm>
-              label="Realms"
-              value={realmFilters}
-              options={realmOptions}
-              onChange={setRealmFilters}
-              inline
-              showSelectAll
-            />
-          </div>
+          <details>
+            <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+              Realms{realmFilters.length > 0 ? ` (${realmFilters.length} selected)` : ''}
+            </summary>
+            <div style={{ marginTop: 6 }}>
+              <CheckboxGroup<Realm>
+                value={realmFilters}
+                options={realmOptions}
+                onChange={setRealmFilters}
+                inline
+                showSelectAll
+              />
+            </div>
+          </details>
+          <details>
+            <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+              Traits{hasActiveTraitFilters ? ` (${Object.keys(traitFilters).length} active)` : ''}
+            </summary>
+            <div style={{ marginTop: 6 }}>
+              <p style={{ margin: '0 0 6px', fontSize: 13, color: 'var(--muted, #666)' }}>
+                Show only professions where each selected trait is at least the chosen value.
+              </p>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, auto)', gap: '8px 16px', alignItems: 'center' }}>
+                {(['caster', 'combat', 'information', 'stealth', 'support', 'utility'] as (keyof CharacterTraits)[]).map((key) => (
+                  <label key={key} style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+                    <span style={{ textTransform: 'capitalize', fontWeight: 600 }}>{key}</span>
+                    <select
+                      value={traitFilters[key] ?? ''}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setTraitFilters((prev) => {
+                          const next = { ...prev };
+                          if (val === '') {
+                            delete next[key];
+                          } else {
+                            next[key] = parseInt(val, 10);
+                          }
+                          return next;
+                        });
+                      }}
+                    >
+                      <option value="">Any</option>
+                      {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => (
+                        <option key={n} value={n}>{n}+</option>
+                      ))}
+                    </select>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </details>
         </div>
       )}
 
@@ -995,6 +1049,15 @@ export default function ProfessionView() {
               </div>
               {errors.stats && <div style={{ color: '#b00020', marginTop: 6 }}>{errors.stats}</div>}
             </section>
+
+            {/* Character Traits */}
+            <div style={{ marginTop: 12 }}>
+              <CharacterTraitsEditor
+                value={form.traits}
+                onChange={(t) => setForm(s => ({ ...s, traits: t }))}
+                disabled={viewing}
+              />
+            </div>
 
             {/* Base Spell List Choices */}
             <section style={{ marginTop: 12 }}>

--- a/src/endpoints/skill/SkillView.tsx
+++ b/src/endpoints/skill/SkillView.tsx
@@ -198,6 +198,7 @@ export default function SkillView() {
   const [query, setQuery] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('');
   const [actionFilter, setActionFilter] = useState<SkillActionType | ''>('');
+  const [traitFilters, setTraitFilters] = useState<Partial<Record<keyof CharacterTraits, number>>>({});
   const [showDescriptionTooltip, setShowDescriptionTooltip] = useState<boolean>(() => {
     try {
       const raw = localStorage.getItem(showDescriptionTooltipStorageKey);
@@ -425,15 +426,20 @@ export default function SkillView() {
     return rows.filter((r) => {
       const matchesCategory = !categoryFilter || r.category === categoryFilter;
       const matchesAction = !actionFilter || r.action === actionFilter;
-      return matchesCategory && matchesAction;
+      if (!matchesCategory || !matchesAction) return false;
+      for (const [key, min] of Object.entries(traitFilters) as [keyof CharacterTraits, number][]) {
+        if (min !== undefined && r.traits[key] < min) return false;
+      }
+      return true;
     });
-  }, [rows, categoryFilter, actionFilter]);
+  }, [rows, categoryFilter, actionFilter, traitFilters]);
 
-  const hasActiveFilters = categoryFilter !== '' || actionFilter !== '';
+  const hasActiveTraitFilters = Object.keys(traitFilters).length > 0;
+  const hasActiveFilters = categoryFilter !== '' || actionFilter !== '' || hasActiveTraitFilters;
 
   useEffect(() => {
     setPage(1);
-  }, [categoryFilter, actionFilter]);
+  }, [categoryFilter, actionFilter, traitFilters]);
 
   useEffect(() => {
     try {
@@ -656,6 +662,7 @@ export default function SkillView() {
                 onClick={() => {
                   setCategoryFilter('');
                   setActionFilter('');
+                  setTraitFilters({});
                 }}
               >
                 Clear filters
@@ -666,6 +673,43 @@ export default function SkillView() {
             <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
             <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
           </div>
+          <details>
+            <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+              Traits{hasActiveTraitFilters ? ` (${Object.keys(traitFilters).length} active)` : ''}
+            </summary>
+            <div style={{ marginTop: 6 }}>
+              <p style={{ margin: '0 0 6px', fontSize: 13, color: 'var(--muted, #666)' }}>
+                Show only skills where each selected trait is at least the chosen value.
+              </p>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, auto)', gap: '8px 16px', alignItems: 'center' }}>
+                {(['caster', 'combat', 'information', 'stealth', 'support', 'utility'] as (keyof CharacterTraits)[]).map((key) => (
+                  <label key={key} style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+                    <span style={{ textTransform: 'capitalize', fontWeight: 600 }}>{key}</span>
+                    <select
+                      value={traitFilters[key] ?? ''}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setTraitFilters((prev) => {
+                          const next = { ...prev };
+                          if (val === '') {
+                            delete next[key];
+                          } else {
+                            next[key] = parseInt(val, 10);
+                          }
+                          return next;
+                        });
+                      }}
+                    >
+                      <option value="">Any</option>
+                      {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => (
+                        <option key={n} value={n}>{n}+</option>
+                      ))}
+                    </select>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </details>
         </div>
       )}
 

--- a/src/endpoints/skill/SkillView.tsx
+++ b/src/endpoints/skill/SkillView.tsx
@@ -9,6 +9,7 @@ import {
 
 import {
   DataTable, DataTableHandle, DataTableSearchInput, type ColumnDef,
+  CharacterTraitsEditor,
   CheckboxInput,
   LabeledInput,
   LabeledSelect,
@@ -23,6 +24,7 @@ import type {
   SkillCategory,
   SkillGroup,
 } from '../../types';
+import type { CharacterTraits } from '../../types/base';
 
 import {
   SKILL_ACTION_TYPES, type SkillActionType,
@@ -69,6 +71,8 @@ type FormState = {
   // floats as strings while typing
   exhaustion: string;
   distanceMultiplier: string;
+
+  traits: CharacterTraits;
 };
 
 type FormErrors = {
@@ -108,6 +112,8 @@ const emptyVM = (): FormState => ({
 
   exhaustion: '',
   distanceMultiplier: '',
+
+  traits: { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 },
 });
 
 function toVM(x: Skill): FormState {
@@ -134,6 +140,7 @@ function toVM(x: Skill): FormState {
 
     exhaustion: String(Number.isFinite(x.exhaustion) ? x.exhaustion : ''),
     distanceMultiplier: String(Number.isFinite(x.distanceMultiplier) ? x.distanceMultiplier : ''),
+    traits: x.traits ?? { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 },
   };
 }
 
@@ -167,6 +174,7 @@ function fromVM(vm: FormState): Skill {
     stats,
     exhaustion,
     distanceMultiplier,
+    traits: vm.traits,
   };
 }
 
@@ -299,11 +307,10 @@ export default function SkillView() {
     if (!draft.action) e.action = 'Action is required';
     else if (!(SKILL_ACTION_TYPES as readonly string[]).includes(draft.action)) e.action = 'Pick a valid SkillActionType';
 
-    // stats: require at least one
+    // stats: optional, but any selected must be valid
     const chosen: Stat[] = [draft.stat1, draft.stat2, draft.stat3].filter(Boolean) as Stat[];
     const validStats = new Set(STATS);
-    if (chosen.length === 0) e.stats = 'Select at least one Stat';
-    else if (!chosen.every(s => validStats.has(s))) e.stats = 'Stats must be valid';
+    if (chosen.length > 0 && !chosen.every(s => validStats.has(s))) e.stats = 'Stats must be valid';
 
     // floats: required and must parse
     const ex = draft.exhaustion.trim();
@@ -915,6 +922,15 @@ export default function SkillView() {
                   </div>
                 </>
               )}
+            </div>
+
+            {/* Character Traits */}
+            <div style={{ marginTop: 12 }}>
+              <CharacterTraitsEditor
+                value={form.traits}
+                onChange={(t) => setForm(s => ({ ...s, traits: t }))}
+                disabled={viewing}
+              />
             </div>
 
             {/* Action buttons */}

--- a/src/endpoints/skillcategory/SkillCategoryView.tsx
+++ b/src/endpoints/skillcategory/SkillCategoryView.tsx
@@ -8,6 +8,7 @@ import {
 
 import {
   DataTable, type DataTableHandle, DataTableSearchInput, type ColumnDef,
+  CharacterTraitsEditor,
   CheckboxInput,
   LabeledInput,
   LabeledSelect,
@@ -20,6 +21,7 @@ import type {
   SkillProgressionType,
   SkillGroup,
 } from '../../types';
+import type { CharacterTraits } from '../../types/base';
 
 import {
   STATS, type Stat,
@@ -44,6 +46,7 @@ type FormState = {
   stat1: Stat | '';
   stat2: Stat | '';
   stat3: Stat | '';
+  traits: CharacterTraits;
 };
 
 type FormErrors = {
@@ -65,6 +68,7 @@ const emptyVM = (): FormState => ({
   stat1: '',
   stat2: '',
   stat3: '',
+  traits: { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 },
 });
 
 const toVM = (x: SkillCategory): FormState => ({
@@ -77,6 +81,7 @@ const toVM = (x: SkillCategory): FormState => ({
   stat1: x.stats[0] ?? '',
   stat2: x.stats[1] ?? '',
   stat3: x.stats[2] ?? '',
+  traits: x.traits ?? { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 },
 });
 
 const fromVM = (vm: FormState): SkillCategory => {
@@ -92,6 +97,7 @@ const fromVM = (vm: FormState): SkillCategory => {
     skillProgression: vm.skillProgression.trim(),
     categoryProgression: vm.categoryProgression.trim(),
     stats,
+    traits: vm.traits,
   };
 };
 
@@ -604,6 +610,15 @@ export default function SkillCategoryView() {
                   />
                 </>
               )}
+            </div>
+
+            {/* Character Traits */}
+            <div style={{ marginTop: 12 }}>
+              <CharacterTraitsEditor
+                value={form.traits}
+                onChange={(t) => setForm(s => ({ ...s, traits: t }))}
+                disabled={viewing}
+              />
             </div>
 
             {/* Action buttons */}

--- a/src/endpoints/skillcategory/SkillCategoryView.tsx
+++ b/src/endpoints/skillcategory/SkillCategoryView.tsx
@@ -120,6 +120,7 @@ export default function SkillCategoryView() {
   // table
   const [query, setQuery] = useState('');
   const [groupFilter, setGroupFilter] = useState('');
+  const [traitFilters, setTraitFilters] = useState<Partial<Record<keyof CharacterTraits, number>>>({});
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
 
@@ -336,13 +337,20 @@ export default function SkillCategoryView() {
   ], [groupNameById, sptNameById]);
 
   const filteredRows = useMemo(
-    () => rows.filter((r) => !groupFilter || r.group === groupFilter),
-    [rows, groupFilter]
+    () => rows.filter((r) => {
+      if (groupFilter && r.group !== groupFilter) return false;
+      for (const [key, min] of Object.entries(traitFilters) as [keyof CharacterTraits, number][]) {
+        if (min !== undefined && r.traits[key] < min) return false;
+      }
+      return true;
+    }),
+    [rows, groupFilter, traitFilters]
   );
 
-  const hasActiveFilters = groupFilter !== '';
+  const hasActiveTraitFilters = Object.keys(traitFilters).length > 0;
+  const hasActiveFilters = groupFilter !== '' || hasActiveTraitFilters;
 
-  useEffect(() => { setPage(1); }, [groupFilter]);
+  useEffect(() => { setPage(1); }, [groupFilter, traitFilters]);
 
   const globalFilter = (r: SkillCategory, q: string) => {
     const s = q.toLowerCase();
@@ -521,12 +529,49 @@ export default function SkillCategoryView() {
               </select>
             </label>
             {hasActiveFilters && (
-              <button onClick={() => setGroupFilter('')}>Clear filters</button>
+              <button onClick={() => { setGroupFilter(''); setTraitFilters({}); }}>Clear filters</button>
             )}
             {/* Reset and auto-fit column widths */}
             <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
             <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
           </div>
+          <details>
+            <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+              Traits{hasActiveTraitFilters ? ` (${Object.keys(traitFilters).length} active)` : ''}
+            </summary>
+            <div style={{ marginTop: 6 }}>
+              <p style={{ margin: '0 0 6px', fontSize: 13, color: 'var(--muted, #666)' }}>
+                Show only skill categories where each selected trait is at least the chosen value.
+              </p>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, auto)', gap: '8px 16px', alignItems: 'center' }}>
+                {(['caster', 'combat', 'information', 'stealth', 'support', 'utility'] as (keyof CharacterTraits)[]).map((key) => (
+                  <label key={key} style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+                    <span style={{ textTransform: 'capitalize', fontWeight: 600 }}>{key}</span>
+                    <select
+                      value={traitFilters[key] ?? ''}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setTraitFilters((prev) => {
+                          const next = { ...prev };
+                          if (val === '') {
+                            delete next[key];
+                          } else {
+                            next[key] = parseInt(val, 10);
+                          }
+                          return next;
+                        });
+                      }}
+                    >
+                      <option value="">Any</option>
+                      {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => (
+                        <option key={n} value={n}>{n}+</option>
+                      ))}
+                    </select>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </details>
         </div>
       )}
 

--- a/src/endpoints/spelllist/SpellListView.tsx
+++ b/src/endpoints/spelllist/SpellListView.tsx
@@ -7,6 +7,7 @@ import {
 
 import {
   DataTable, type DataTableHandle, DataTableSearchInput, type ColumnDef,
+  CharacterTraitsEditor,
   CheckboxGroup,
   CheckboxInput,
   LabeledInput,
@@ -20,6 +21,7 @@ import type {
   Book,
   SpellList,
 } from '../../types';
+import type { CharacterTraits } from '../../types/base';
 
 import {
   SPELL_TYPES, SpellType,
@@ -40,9 +42,12 @@ type FormState = {
   name: string;
   book: string;
   type: string;          // keep as string while typing; validate to SpellType
+  description: string;
   evil: boolean;
   summoning: boolean;
+  directed: boolean;
   realms: Realm[];       // keep as Realm[] in the form (CheckboxGroup)
+  traits: CharacterTraits;
 };
 
 type FormErrors = {
@@ -54,10 +59,10 @@ type FormErrors = {
 };
 
 function emptyVM(): FormState {
-  return { id: prefix, name: '', book: '', type: '', evil: false, summoning: false, realms: [] };
+  return { id: prefix, name: '', book: '', type: '', description: '', evil: false, summoning: false, directed: false, realms: [], traits: { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 } };
 }
 function toVM(s: SpellList): FormState {
-  return { ...s, type: s.type };
+  return { ...s, type: s.type, traits: s.traits ?? { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 } };
 }
 
 function fromVM(vm: FormState): SpellList {
@@ -66,9 +71,12 @@ function fromVM(vm: FormState): SpellList {
     name: vm.name.trim(),
     book: vm.book.trim(),
     type: vm.type.trim() as SpellType,        // safe after validation
+    description: vm.description.trim(),
     evil: !!vm.evil,
     summoning: !!vm.summoning,
+    directed: !!vm.directed,
     realms: [...vm.realms],
+    traits: vm.traits,
   };
 }
 
@@ -84,7 +92,9 @@ export default function SpellListView() {
   const [typeFilter, setTypeFilter] = useState<SpellType | ''>('');
   const [evilFilter, setEvilFilter] = useState('');
   const [summoningFilter, setSummoningFilter] = useState('');
+  const [bookFilters, setBookFilters] = useState<string[]>([]);
   const [realmFilters, setRealmFilters] = useState<Realm[]>([]);
+  const [traitFilters, setTraitFilters] = useState<Partial<Record<keyof CharacterTraits, number>>>({});
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
 
@@ -138,6 +148,21 @@ export default function SpellListView() {
     [books]
   );
 
+  const bookFilterOptions = useMemo(() => {
+    const ids = new Set<string>();
+    for (const row of rows) {
+      if (row.book) ids.add(row.book);
+    }
+    return Array.from(ids)
+      .map((id) => ({ value: id, label: bookNameById.get(id) ?? id }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [rows, bookNameById]);
+
+  useEffect(() => {
+    const allowed = new Set(bookFilterOptions.map((o) => o.value));
+    setBookFilters((prev) => prev.filter((id) => allowed.has(id)));
+  }, [bookFilterOptions]);
+
 
   /* ------------------------------------------------------------------ */
   /* Validation                                                         */
@@ -183,6 +208,7 @@ export default function SpellListView() {
     return [
       { id: 'id', header: 'ID', accessor: r => r.id, sortType: 'string', minWidth: 260 },
       { id: 'name', header: 'Name', accessor: r => r.name, sortType: 'string', minWidth: 160 },
+      { id: 'description', header: 'Description', accessor: r => r.description, sortType: 'string', minWidth: 200 },
 
       {
         id: 'book', header: 'Book', accessor: (r) => bookNameById.get(r.book) ?? r.book, sortType: 'string', minWidth: 240,
@@ -200,6 +226,10 @@ export default function SpellListView() {
       {
         id: 'summoning', header: 'Summoning', accessor: r => Number(r.summoning), sortType: 'number', minWidth: 90,
         render: r => (r.summoning ? 'Yes' : 'No'),
+      },
+      {
+        id: 'directed', header: 'Directed', accessor: r => Number(r.directed), sortType: 'number', minWidth: 90,
+        render: r => (r.directed ? 'Yes' : 'No'),
       },
       {
         id: 'realms', header: 'Realms', accessor: r => r.realms.length, sortType: 'number', minWidth: 260,
@@ -224,15 +254,20 @@ export default function SpellListView() {
       if (typeFilter && r.type !== typeFilter) return false;
       if (evilFilter !== '' && r.evil !== (evilFilter === 'true')) return false;
       if (summoningFilter !== '' && r.summoning !== (summoningFilter === 'true')) return false;
+      if (bookFilters.length > 0 && !bookFilters.includes(r.book)) return false;
       if (realmFilters.length > 0 && !realmFilters.every((realm) => r.realms.includes(realm))) return false;
+      for (const [key, min] of Object.entries(traitFilters) as [keyof CharacterTraits, number][]) {
+        if (min !== undefined && r.traits[key] < min) return false;
+      }
       return true;
     }),
-    [rows, typeFilter, evilFilter, summoningFilter, realmFilters]
+    [rows, typeFilter, evilFilter, summoningFilter, bookFilters, realmFilters, traitFilters]
   );
 
-  const hasActiveFilters = typeFilter !== '' || evilFilter !== '' || summoningFilter !== '' || realmFilters.length > 0;
+  const hasActiveTraitFilters = Object.keys(traitFilters).length > 0;
+  const hasActiveFilters = typeFilter !== '' || evilFilter !== '' || summoningFilter !== '' || bookFilters.length > 0 || realmFilters.length > 0 || hasActiveTraitFilters;
 
-  useEffect(() => { setPage(1); }, [typeFilter, evilFilter, summoningFilter, realmFilters]);
+  useEffect(() => { setPage(1); }, [typeFilter, evilFilter, summoningFilter, bookFilters, realmFilters, traitFilters]);
 
   const globalFilter = (r: SpellList, q: string) => {
     const s = q.toLowerCase();
@@ -425,21 +460,79 @@ export default function SpellListView() {
               </select>
             </label>
             {hasActiveFilters && (
-              <button onClick={() => { setTypeFilter(''); setEvilFilter(''); setSummoningFilter(''); setRealmFilters([]); }}>Clear filters</button>
+              <button onClick={() => { setTypeFilter(''); setEvilFilter(''); setSummoningFilter(''); setBookFilters([]); setRealmFilters([]); setTraitFilters({}); }}>Clear filters</button>
             )}
             {/* Reset and auto-fit column widths */}
             <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
             <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
           </div>
-          <CheckboxGroup<Realm>
-            label="Realms"
-            value={realmFilters}
-            options={SPELL_REALMS}
-            onChange={setRealmFilters}
-            inline
-            showSelectAll
-            columns={4}
-          />
+          <details>
+            <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+              Books{bookFilters.length > 0 ? ` (${bookFilters.length} selected)` : ''}
+            </summary>
+            <div style={{ marginTop: 6 }}>
+              <CheckboxGroup<string>
+                value={bookFilters}
+                options={bookFilterOptions}
+                onChange={setBookFilters}
+                inline
+                showSelectAll
+                columns={4}
+              />
+            </div>
+          </details>
+          <details>
+            <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+              Realms{realmFilters.length > 0 ? ` (${realmFilters.length} selected)` : ''}
+            </summary>
+            <div style={{ marginTop: 6 }}>
+              <CheckboxGroup<Realm>
+                value={realmFilters}
+                options={SPELL_REALMS}
+                onChange={setRealmFilters}
+                inline
+                showSelectAll
+                columns={5}
+              />
+            </div>
+          </details>
+          <details>
+            <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+              Traits{hasActiveTraitFilters ? ` (${Object.keys(traitFilters).length} active)` : ''}
+            </summary>
+            <div style={{ marginTop: 6 }}>
+              <p style={{ margin: '0 0 6px', fontSize: 13, color: 'var(--muted, #666)' }}>
+                Show only spell lists where each selected trait is at least the chosen value.
+              </p>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, auto)', gap: '8px 16px', alignItems: 'center' }}>
+                {(['caster', 'combat', 'information', 'stealth', 'support', 'utility'] as (keyof CharacterTraits)[]).map((key) => (
+                  <label key={key} style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+                    <span style={{ textTransform: 'capitalize', fontWeight: 600 }}>{key}</span>
+                    <select
+                      value={traitFilters[key] ?? ''}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setTraitFilters((prev) => {
+                          const next = { ...prev };
+                          if (val === '') {
+                            delete next[key];
+                          } else {
+                            next[key] = parseInt(val, 10);
+                          }
+                          return next;
+                        });
+                      }}
+                    >
+                      <option value="">Any</option>
+                      {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => (
+                        <option key={n} value={n}>{n}+</option>
+                      ))}
+                    </select>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </details>
         </div>
       )}
 
@@ -455,6 +548,10 @@ export default function SpellListView() {
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
               <LabeledInput label="ID" value={form.id} onChange={makeIDOnChange<typeof form>('id', setForm, prefix)} disabled={!!editingId || viewing} error={errors.id} />
               <LabeledInput label="Name" value={form.name} onChange={(v) => setForm(s => ({ ...s, name: v }))} disabled={viewing} error={errors.name} />
+
+              <div style={{ gridColumn: '1 / -1' }}>
+                <LabeledInput label="Description" value={form.description} onChange={(v) => setForm(s => ({ ...s, description: v }))} disabled={viewing} />
+              </div>
 
               <LabeledSelect
                 label="Book"
@@ -475,8 +572,11 @@ export default function SpellListView() {
                 error={viewing ? undefined : errors.type}
               />
 
-              <CheckboxInput label="Evil" checked={form.evil} onChange={(c) => setForm(s => ({ ...s, evil: c }))} disabled={viewing} />
-              <CheckboxInput label="Summoning" checked={form.summoning} onChange={(c) => setForm(s => ({ ...s, summoning: c }))} disabled={viewing} />
+              <div style={{ gridColumn: '1 / -1', display: 'flex', gap: 24 }}>
+                <CheckboxInput label="Evil" checked={form.evil} onChange={(c) => setForm(s => ({ ...s, evil: c }))} disabled={viewing} />
+                <CheckboxInput label="Summoning" checked={form.summoning} onChange={(c) => setForm(s => ({ ...s, summoning: c }))} disabled={viewing} />
+                <CheckboxInput label="Directed" checked={form.directed} onChange={(c) => setForm(s => ({ ...s, directed: c }))} disabled={viewing} />
+              </div>
 
               <div style={{ gridColumn: '1 / -1' }}>
                 <CheckboxGroup<Realm>
@@ -487,10 +587,18 @@ export default function SpellListView() {
                   disabled={viewing}
                   error={viewing ? undefined : errors.realms}
                   helperText="Select at least one"
-                  columns={4}
+                  columns={5}
                   showSelectAll
                 />
               </div>
+            </div>
+
+            <div style={{ marginTop: 12 }}>
+              <CharacterTraitsEditor
+                value={form.traits}
+                onChange={(t) => setForm(s => ({ ...s, traits: t }))}
+                disabled={viewing}
+              />
             </div>
 
             {/* Action buttons */}

--- a/src/endpoints/trainingpackage/TrainingPackageView.tsx
+++ b/src/endpoints/trainingpackage/TrainingPackageView.tsx
@@ -14,6 +14,7 @@ import {
 
 import {
   DataTable, type DataTableHandle, DataTableSearchInput, type ColumnDef,
+  CharacterTraitsEditor,
   CheckboxGroup,
   CheckboxInput,
   ChoiceListEditor,
@@ -45,6 +46,7 @@ import type {
   SpellList,
   TrainingPackage,
 } from '../../types';
+import type { CharacterTraits } from '../../types/base';
 
 import {
   STATS, type Stat,
@@ -186,6 +188,8 @@ type FormState = {
     value: string;
     options: string[];
   }[];
+
+  traits: CharacterTraits;
 };
 
 type FormErrors = {
@@ -270,6 +274,8 @@ const emptyVM = (): FormState => ({
   lifestyleCategorySkillChoices: [],
 
   languageChoices: [],
+
+  traits: { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 },
 });
 
 const toVM = (x: TrainingPackage): FormState => ({
@@ -375,6 +381,8 @@ const toVM = (x: TrainingPackage): FormState => ({
     value: String(r.value),
     options: r.options.slice(),
   })),
+
+  traits: x.traits ?? { caster: 5, combat: 5, information: 5, stealth: 5, support: 5, utility: 5 },
 });
 
 const fromVM = (vm: FormState): TrainingPackage => ({
@@ -480,6 +488,8 @@ const fromVM = (vm: FormState): TrainingPackage => ({
     value: Number(r.value),
     options: r.options.slice(),
   })),
+
+  traits: vm.traits,
 });
 
 /* ------------------------------------------------------------------ */
@@ -508,6 +518,7 @@ export default function TrainingPackagesView() {
   const [bookFilters, setBookFilters] = useState<string[]>([]);
   const [raceFilters, setRaceFilters] = useState<string[]>([]);
   const [anyRaceOnlyFilter, setAnyRaceOnlyFilter] = useState(false);
+  const [traitFilters, setTraitFilters] = useState<Partial<Record<keyof CharacterTraits, number>>>({});
   const [showDescriptionTooltip, setShowDescriptionTooltip] = useState<boolean>(() => {
     try {
       const raw = localStorage.getItem(showDescriptionTooltipStorageKey);
@@ -1142,14 +1153,18 @@ export default function TrainingPackagesView() {
       if (bookFilters.length > 0 && !bookFilters.includes(r.book)) return false;
       if (anyRaceOnlyFilter && rowRaces.length > 0) return false;
       if (!anyRaceOnlyFilter && raceFilters.length > 0 && !raceFilters.every((raceId) => rowRaces.includes(raceId))) return false;
+      for (const [key, min] of Object.entries(traitFilters) as [keyof CharacterTraits, number][]) {
+        if (min !== undefined && r.traits[key] < min) return false;
+      }
       return true;
     }),
-    [rows, lifestyleFilter, bookFilters, raceFilters, anyRaceOnlyFilter]
+    [rows, lifestyleFilter, bookFilters, raceFilters, anyRaceOnlyFilter, traitFilters]
   );
 
-  const hasActiveFilters = lifestyleFilter !== '' || bookFilters.length > 0 || raceFilters.length > 0 || anyRaceOnlyFilter;
+  const hasActiveTraitFilters = Object.keys(traitFilters).length > 0;
+  const hasActiveFilters = lifestyleFilter !== '' || bookFilters.length > 0 || raceFilters.length > 0 || anyRaceOnlyFilter || hasActiveTraitFilters;
 
-  useEffect(() => { setPage(1); }, [lifestyleFilter, bookFilters, raceFilters, anyRaceOnlyFilter]);
+  useEffect(() => { setPage(1); }, [lifestyleFilter, bookFilters, raceFilters, anyRaceOnlyFilter, traitFilters]);
 
   const globalFilter = (r: TrainingPackage, q: string) => {
     const rowRaces = getRowRaces(r);
@@ -1360,7 +1375,7 @@ export default function TrainingPackagesView() {
               Show description tooltip
             </label>
             {hasActiveFilters && (
-              <button onClick={() => { setLifestyleFilter(''); setBookFilters([]); setRaceFilters([]); setAnyRaceOnlyFilter(false); }}>Clear filters</button>
+              <button onClick={() => { setLifestyleFilter(''); setBookFilters([]); setRaceFilters([]); setAnyRaceOnlyFilter(false); setTraitFilters({}); }}>Clear filters</button>
             )}
 
             {/* Reset and auto-fit column widths */}
@@ -1401,6 +1416,44 @@ export default function TrainingPackagesView() {
                 showSelectAll
                 columns={4}
               />
+            </div>
+          </details>
+
+          <details>
+            <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+              Traits{hasActiveTraitFilters ? ` (${Object.keys(traitFilters).length} active)` : ''}
+            </summary>
+            <div style={{ marginTop: 6 }}>
+              <p style={{ margin: '0 0 6px', fontSize: 13, color: 'var(--muted, #666)' }}>
+                Show only packages where each selected trait is at least the chosen value.
+              </p>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, auto)', gap: '8px 16px', alignItems: 'center' }}>
+                {(['caster', 'combat', 'information', 'stealth', 'support', 'utility'] as (keyof CharacterTraits)[]).map((key) => (
+                  <label key={key} style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+                    <span style={{ textTransform: 'capitalize', fontWeight: 600 }}>{key}</span>
+                    <select
+                      value={traitFilters[key] ?? ''}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setTraitFilters((prev) => {
+                          const next = { ...prev };
+                          if (val === '') {
+                            delete next[key];
+                          } else {
+                            next[key] = parseInt(val, 10);
+                          }
+                          return next;
+                        });
+                      }}
+                    >
+                      <option value="">Any</option>
+                      {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => (
+                        <option key={n} value={n}>{n}+</option>
+                      ))}
+                    </select>
+                  </label>
+                ))}
+              </div>
             </div>
           </details>
         </div>
@@ -1829,6 +1882,15 @@ export default function TrainingPackagesView() {
               viewing={viewing}
               error={errors.languageChoices}
             />
+
+            {/* Character Traits */}
+            <div style={{ marginTop: 12 }}>
+              <CharacterTraitsEditor
+                value={form.traits}
+                onChange={(t) => setForm(s => ({ ...s, traits: t }))}
+                disabled={viewing}
+              />
+            </div>
 
             {/* Action buttons */}
             <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -29,3 +29,12 @@ export interface MaladySymptom {
   severity: MaladySeverity;
   symptoms: string;
 }
+
+export interface CharacterTraits {
+  caster: number;
+  combat: number;
+  information: number;
+  stealth: number;
+  support: number;
+  utility: number;
+}

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -35,6 +35,7 @@ export interface CharacterBuilder extends Named {
   autoBuilder: string;
   built: boolean;
   pc: boolean;
+  autoBuild: boolean;
   race: string; // Race.id
   culture: string; // Culture.id
   cultureType: string;  // CultureType.id
@@ -127,6 +128,7 @@ export function createEmptyCharacterBuilder(): CharacterBuilder {
     autoBuilder: '',
     built: false,
     pc: false,
+    autoBuild: false,
     race: '',
     culture: '',
     cultureType: '',

--- a/src/types/profession.ts
+++ b/src/types/profession.ts
@@ -8,6 +8,7 @@ import type {
 } from './enum';
 
 import type { Named, PersistentValue, PersistentDevelopmentTypeValue, SkillDevelopmentTypeValue, SkillValue } from './base';
+import type { CharacterTraits } from './base';
 
 export interface ProfessionSpellListChoice {
   numChoices: number;
@@ -70,6 +71,7 @@ export interface Profession extends Named {
   skillGroupSkillDevelopmentTypeChoices: ProfessionGroupSkillDevelopmentTypeChoice[];
 
   skillCategoryCosts: ProfessionSkillCategoryCost[];
+  traits: CharacterTraits;
 }
 
 export interface ProfessionsPayload {

--- a/src/types/skill.ts
+++ b/src/types/skill.ts
@@ -2,7 +2,7 @@
 // Skill
 // ------------------------
 import type { SkillActionType, Stat } from './enum';
-import type { Named } from './base';
+import type { CharacterTraits, Named } from './base';
 
 export interface Skill extends Named {
   /** references SkillCategory.id */
@@ -33,6 +33,9 @@ export interface Skill extends Named {
   /** floats */
   exhaustion: number;
   distanceMultiplier: number;
+
+  /** character traits */
+  traits: CharacterTraits;
 }
 
 export interface SkillsPayload {

--- a/src/types/skillcategory.ts
+++ b/src/types/skillcategory.ts
@@ -2,7 +2,7 @@
 // Skill Categories
 // ------------------------
 import type { Stat } from './enum'; // adjust the relative path if needed
-import { Named } from './base';
+import type { CharacterTraits, Named } from './base';
 
 export interface SkillCategory extends Named {
   group: string;                 // SkillGroup.id
@@ -10,6 +10,9 @@ export interface SkillCategory extends Named {
   skillProgression: string;      // SkillProgressionType.id
   categoryProgression: string;   // SkillProgressionType.id
   stats: Stat[];                 // keep order & duplicates
+
+  /** character traits */
+  traits: CharacterTraits;
 }
 
 export interface SkillCategoriesPayload {

--- a/src/types/spelllist.ts
+++ b/src/types/spelllist.ts
@@ -1,12 +1,15 @@
 import { SpellType, Realm } from './enum';
-import type { Named } from './base';
+import type { CharacterTraits, Named } from './base';
 
 export interface SpellList extends Named {
   book: string;
   type: SpellType;
+  description: string;
   evil: boolean;
   summoning: boolean;
+  directed: boolean;
   realms: Realm[];
+  traits: CharacterTraits;
 }
 
 export interface SpellListsPayload {

--- a/src/types/trainingpackage.ts
+++ b/src/types/trainingpackage.ts
@@ -1,5 +1,5 @@
 import type { Stat } from './enum';
-import type { Named, PersistentValue, SkillValue } from './base';
+import type { CharacterTraits, Named, PersistentValue, SkillValue } from './base';
 
 export interface TrainingPackageQualifier {
   qualifier: string;
@@ -97,6 +97,9 @@ export interface TrainingPackage extends Named {
   }>;
 
   languageChoices: TrainingPackageLanguageChoice[];
+
+  /** character traits */
+  traits: CharacterTraits;
 }
 
 export interface TrainingPackagesPayload {


### PR DESCRIPTION
This pull request introduces support for "traits" (a set of six numeric attributes) across several core data types—skills, skill categories, spell lists, professions, and training packages—by adding consistent parsing and serialization logic throughout the API layer. Additionally, it improves the DataTable component by persisting sort state in local storage and introduces a reusable `CharacterTraitsEditor` input component. Some unused or redundant API code has also been removed for clarity.

**Trait support across data types:**

* Added `traitsFromJson` utility and integrated it into the API loaders for `Skill`, `SkillCategory`, `SpellList`, `Profession`, and `TrainingPackage` so that each now correctly parses and exposes a `traits` field of type `CharacterTraits` from backend data. [[1]](diffhunk://#diff-bb60fdd853c2a6e4bf9680e6c3faeaba464e98101d61c44ba9d8b4b6bde0c7beR30-R45) [[2]](diffhunk://#diff-bb60fdd853c2a6e4bf9680e6c3faeaba464e98101d61c44ba9d8b4b6bde0c7beR198) [[3]](diffhunk://#diff-aedbdf589707d64c2c184b04ea6c7feb9ab7334756888c2f794b06b207e74cb8R16-R36) [[4]](diffhunk://#diff-aedbdf589707d64c2c184b04ea6c7feb9ab7334756888c2f794b06b207e74cb8R58) [[5]](diffhunk://#diff-dafb51eec5d65c8b9a093ba6729780a10a033c35c00c01f41fa70d54a4af8ec5R17-R32) [[6]](diffhunk://#diff-dafb51eec5d65c8b9a093ba6729780a10a033c35c00c01f41fa70d54a4af8ec5R59) [[7]](diffhunk://#diff-37d41be7e2ba188b4be5977e5ecb5e5bcd0e11b07159ce6d177e21f7bdf11db7R30-R44) [[8]](diffhunk://#diff-37d41be7e2ba188b4be5977e5ecb5e5bcd0e11b07159ce6d177e21f7bdf11db7R57-R62) [[9]](diffhunk://#diff-0015caf32aff0b0dfe79015d07aefacdcb0967bbe59bac0d542f57cd077df8cbR18-R43)

* Exported the new `CharacterTraitsEditor` input component for editing these traits, and included it in the public input components index. [[1]](diffhunk://#diff-b6bb7b618fdcbf0bfcff92c94fef7959a732d98b1a4781c8416a7711122ce542R1-R84) [[2]](diffhunk://#diff-826546160d96c814d8f68b64d417b947f012e88ced18007503a3b50a54cd5da9R2)

**DataTable improvements:**

* Added persistence for sort state using local storage, so user sorting preferences are retained across sessions. [[1]](diffhunk://#diff-3fd80f7ce4eed9fb9c23df0ce14230ff017fc9f4eed6a073617471370aeeb848R54-R74) [[2]](diffhunk://#diff-3fd80f7ce4eed9fb9c23df0ce14230ff017fc9f4eed6a073617471370aeeb848L283-R304) [[3]](diffhunk://#diff-3fd80f7ce4eed9fb9c23df0ce14230ff017fc9f4eed6a073617471370aeeb848L383-R409)

**API and UI cleanup:**

* Removed the unused `autoCharacterStats` API endpoint and related imports, updating the character creation flow to use `setCharacterStats` with an `autoBuild` flag instead. [[1]](diffhunk://#diff-0f4522a4c85f1b8a61d42825272cd14449257f189427df2c9844922558d60cd8L19) [[2]](diffhunk://#diff-0f4522a4c85f1b8a61d42825272cd14449257f189427df2c9844922558d60cd8L53-L58) [[3]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L13-L15) [[4]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5L51) [[5]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R1967-R1989)

* Added an "Auto initial choices" handler to the character creation view, allowing initial choices to be auto-filled in a similar way to stats. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R380) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R1967-R1989)

**UI component polish:**

* Made the `CheckboxGroup` label optional and only rendered the `<legend>` if a label is provided. [[1]](diffhunk://#diff-aaee1a87d6b5d621f474a1b08e470a6bfd37fc037ff05e146c0c58dde672ddf8L9-R9) [[2]](diffhunk://#diff-aaee1a87d6b5d621f474a1b08e470a6bfd37fc037ff05e146c0c58dde672ddf8R127-R131)