### PR TITLE
Auto create to level 1

### DIFF
--- a/src/api/characterworkflow.ts
+++ b/src/api/characterworkflow.ts
@@ -68,6 +68,12 @@ export async function setCharacterHobbyChoices(
   return sendJson<CharacterBuilder>(SET_HOBBY_CHOICES_ENDPOINT, 'POST', payload);
 }
 
+export async function autoPrimaryCharacter(
+  payload: CharacterBuilder,
+): Promise<Character> {
+  return sendJson<Character>('/rmce/operations/character/auto-primary', 'POST', payload);
+}
+
 export async function setCharacterBackgroundChoices(
   payload: SetCharacterBackgroundChoicesRequest,
 ): Promise<Character> {

--- a/src/api/characterworkflow.ts
+++ b/src/api/characterworkflow.ts
@@ -4,6 +4,7 @@ import type { Character, CharacterBuilder, CharacterLeveller, PersistentValue, L
 
 export type SetCharacterBackgroundChoicesRequest = {
   id: string;
+  autoBuild?: boolean;
   statGains: boolean;
   extraMoney: 0 | 1 | 2;
   backgroundLanguages: LanguageAbility[];

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -380,6 +380,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
   const [autoingInitialChoices, setAutoingInitialChoices] = useState(false);
   const [savingStats, setSavingStats] = useState(false);
   const [autoingStats, setAutoingStats] = useState(false);
+  const [autoingHobbyChoices, setAutoingHobbyChoices] = useState(false);
   const [savingHobbyChoices, setSavingHobbyChoices] = useState(false);
   const [savingBackgroundChoices, setSavingBackgroundChoices] = useState(false);
   const [applying, setApplying] = useState(false);
@@ -1996,6 +1997,23 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
     } finally {
       setAutoingStats(false);
       setSavingStats(false);
+    }
+  };
+
+  const handleAutoHobbyChoices = async () => {
+    if (autoingHobbyChoices) return;
+    setAutoingHobbyChoices(true);
+    setSavingHobbyChoices(true);
+    try {
+      const response = await setCharacterHobbyChoices({ ...characterBuilder, autoBuild: true });
+      setCharacterBuilder(response);
+      const next = STEP_ORDER[STEP_ORDER.indexOf('hobby') + 1];
+      if (next) setStep(next);
+    } catch (e) {
+      toast({ variant: 'danger', title: 'Auto hobby choices failed', description: String(e instanceof Error ? e.message : e) });
+    } finally {
+      setAutoingHobbyChoices(false);
+      setSavingHobbyChoices(false);
     }
   };
 
@@ -3890,6 +3908,11 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
               {step === 'stats' && (
                 <button type="button" onClick={handleAutoStats} disabled={autoingStats || savingStats}>
                   {autoingStats ? 'Auto…' : 'Auto'}
+                </button>
+              )}
+              {step === 'hobby' && (
+                <button type="button" onClick={handleAutoHobbyChoices} disabled={autoingHobbyChoices || savingHobbyChoices}>
+                  {autoingHobbyChoices ? 'Auto…' : 'Auto'}
                 </button>
               )}
               <button type="button" onClick={goNext} disabled={!canGoNext || savingPrimaryDefinition || savingInitialChoices || savingStats || savingPhysique || savingHobbyChoices || savingBackgroundChoices}>Next</button>

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -382,6 +382,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
   const [autoingStats, setAutoingStats] = useState(false);
   const [autoingHobbyChoices, setAutoingHobbyChoices] = useState(false);
   const [savingHobbyChoices, setSavingHobbyChoices] = useState(false);
+  const [autoingBackgroundChoices, setAutoingBackgroundChoices] = useState(false);
   const [savingBackgroundChoices, setSavingBackgroundChoices] = useState(false);
   const [applying, setApplying] = useState(false);
 
@@ -2014,6 +2015,24 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
     } finally {
       setAutoingHobbyChoices(false);
       setSavingHobbyChoices(false);
+    }
+  };
+
+  const handleAutoBackgroundChoices = async () => {
+    if (autoingBackgroundChoices) return;
+    setAutoingBackgroundChoices(true);
+    setSavingBackgroundChoices(true);
+    try {
+      if (!characterBuilder.id) throw new Error('Character builder id is missing.');
+      const response = await setCharacterBackgroundChoices({ id: characterBuilder.id, autoBuild: true, statGains: false, extraMoney: 0, backgroundLanguages: [], backgroundSkillBonus: [], backgroundCategoryBonus: [], backgroundItemCount: 0, spellListSpecialBonuses: [] });
+      setCreatedCharacter(response);
+      const next = STEP_ORDER[STEP_ORDER.indexOf('background') + 1];
+      if (next) setStep(next);
+    } catch (e) {
+      toast({ variant: 'danger', title: 'Auto background choices failed', description: String(e instanceof Error ? e.message : e) });
+    } finally {
+      setAutoingBackgroundChoices(false);
+      setSavingBackgroundChoices(false);
     }
   };
 
@@ -3913,6 +3932,11 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
               {step === 'hobby' && (
                 <button type="button" onClick={handleAutoHobbyChoices} disabled={autoingHobbyChoices || savingHobbyChoices}>
                   {autoingHobbyChoices ? 'Auto…' : 'Auto'}
+                </button>
+              )}
+              {step === 'background' && (
+                <button type="button" onClick={handleAutoBackgroundChoices} disabled={autoingBackgroundChoices || savingBackgroundChoices}>
+                  {autoingBackgroundChoices ? 'Auto…' : 'Auto'}
                 </button>
               )}
               <button type="button" onClick={goNext} disabled={!canGoNext || savingPrimaryDefinition || savingInitialChoices || savingStats || savingPhysique || savingHobbyChoices || savingBackgroundChoices}>Next</button>

--- a/src/endpoints/character/CharacterCreationView.tsx
+++ b/src/endpoints/character/CharacterCreationView.tsx
@@ -18,6 +18,7 @@ import {
   setCharacterHobbyChoices,
   setCharacterPrimaryChoices,
   setPrimaryDefinition,
+  autoPrimaryCharacter,
   type SetCharacterBackgroundChoicesRequest,
 } from '../../api';
 
@@ -384,6 +385,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
   const [savingHobbyChoices, setSavingHobbyChoices] = useState(false);
   const [autoingBackgroundChoices, setAutoingBackgroundChoices] = useState(false);
   const [savingBackgroundChoices, setSavingBackgroundChoices] = useState(false);
+  const [autoingPrimary, setAutoingPrimary] = useState(false);
   const [applying, setApplying] = useState(false);
 
   useEffect(() => {
@@ -2033,6 +2035,28 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
     } finally {
       setAutoingBackgroundChoices(false);
       setSavingBackgroundChoices(false);
+    }
+  };
+
+  const handleAutoPrimary = async () => {
+    if (autoingPrimary) return;
+    setAutoingPrimary(true);
+    try {
+      const response = await autoPrimaryCharacter({
+        ...characterBuilder,
+        name: characterName.trim(),
+        pc: isPC,
+        race: raceId,
+        culture: cultureId,
+        profession: professionId,
+        magicalRealms: selectedRealms,
+      });
+      setCreatedCharacter(response);
+      setStep('summary');
+    } catch (e) {
+      toast({ variant: 'danger', title: 'Auto build failed', description: String(e instanceof Error ? e.message : e) });
+    } finally {
+      setAutoingPrimary(false);
     }
   };
 
@@ -3884,7 +3908,7 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
             </section>
           )}
 
-          {step === 'summary' && (
+          {step === 'summary' && createdCharacter && (
             <section style={{ display: 'grid', gap: 12 }}>
               <div style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 10 }}>
                 <h4 style={{ margin: '0 0 8px' }}>Summary</h4>
@@ -3892,10 +3916,10 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
                   <li>Name: {characterName || 'None'}</li>
                   <li>Sex: {characterBuilder.male ? 'Male' : 'Female'}</li>
                   <li>Race: {race?.name ?? raceId}</li>
-                  <li>Height: {characterBuilder.height > 0 ? `${Math.floor(characterBuilder.height / 12)}' ${characterBuilder.height % 12}"` : 'Not generated'}</li>
-                  <li>Weight: {characterBuilder.weight > 0 ? `${characterBuilder.weight} lbs` : 'Not generated'}</li>
-                  <li>Build: {characterBuilder.buildDescription || 'Not generated'}</li>
-                  <li>Expected Lifespan: {characterBuilder.lifespan > 0 ? `${characterBuilder.lifespan} years` : 'Not generated'}</li>
+                  <li>Height: {createdCharacter.height > 0 ? `${Math.floor(createdCharacter.height / 12)}' ${createdCharacter.height % 12}"` : 'Not generated'}</li>
+                  <li>Weight: {createdCharacter.weight > 0 ? `${createdCharacter.weight} lbs` : 'Not generated'}</li>
+                  <li>Build: {createdCharacter.buildDescription || 'Not generated'}</li>
+                  <li>Expected Lifespan: {createdCharacter.lifespan > 0 ? `${createdCharacter.lifespan} years` : 'Not generated'}</li>
                   <li>Culture: {culture?.name ?? cultureId}</li>
                   <li>Profession: {profession?.name ?? professionId}</li>
                   <li>Realms: {selectedRealms.join(', ') || 'None'}</li>
@@ -3919,6 +3943,11 @@ export default function CharacterCreationView({ onFinish }: { onFinish?: (create
           {step !== 'summary' && (<>
             <div style={{ display: 'flex', gap: 8 }}>
               <button type="button" onClick={goPrev} disabled={step === 'primary'}>Back</button>
+              {step === 'primary' && (
+                <button type="button" onClick={handleAutoPrimary} disabled={autoingPrimary}>
+                  {autoingPrimary ? 'Auto Build…' : 'Auto Build'}
+                </button>
+              )}
               {step === 'initial' && (
                 <button type="button" onClick={handleAutoInitialChoices} disabled={autoingInitialChoices || savingInitialChoices}>
                   {autoingInitialChoices ? 'Auto…' : 'Auto'}


### PR DESCRIPTION
This pull request adds new "auto-build" functionality to the character creation workflow, allowing users to automatically generate hobby, background, and primary choices with a single click. It introduces new API support for these features, updates UI state management, and ensures that the character summary displays the finalized character data after auto-building.

**Auto-build functionality enhancements:**

* Added new API endpoint and function `autoPrimaryCharacter` to automatically generate primary character choices.
* Updated `setCharacterBackgroundChoices` API to support an optional `autoBuild` flag, enabling automated background choice generation.

**UI and user experience improvements:**

* Introduced new state variables (`autoingHobbyChoices`, `autoingBackgroundChoices`, `autoingPrimary`) and handler functions in `CharacterCreationView` to manage and trigger auto-build actions for hobby, background, and primary steps. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R384-R388) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R2006-R2062)
* Added "Auto" buttons to the UI for the hobby, background, and primary steps, allowing users to trigger auto-generation for each section. [[1]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R3946-R3950) [[2]](diffhunk://#diff-f1166dddba104b7276e185244889e515844c5b493d2e730c8a2bb18feb0bdfa5R3961-R3970)

**Summary display update:**

* Modified the summary step to display data from the finalized `createdCharacter` object, ensuring that auto-generated values are shown to the user.