### PR TITLE
Add Foragable resource editing

### DIFF
--- a/src/api/foragable.ts
+++ b/src/api/foragable.ts
@@ -1,0 +1,78 @@
+import { fetchJson, sendJson } from './client';
+
+import type {
+  Foragable,
+  ForagablesPayload,
+} from '../types/foragable';
+
+import {
+  FORAGABLE_EFFECT_TYPES,
+  FORAGABLE_PREPARATION_TYPES,
+  MANOEUVRE_DIFFICULTIES,
+  asFeatureArray,
+  asTerrainArray,
+  asVegetationArray,
+  asWaterBodyArray,
+  type ForagableEffectType,
+  type ForagablePreparationType,
+  type ManoeuvreDifficulty,
+} from '../types/enum';
+
+const BASE = '/rmce/data/foragable';
+
+const asString = (v: unknown) => String(v ?? '');
+const asInt = (v: unknown) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.trunc(n) : NaN;
+};
+const asStringArray = (v: unknown): string[] =>
+  Array.isArray(v) ? v.map((x) => String(x ?? '')).filter(Boolean) : [];
+
+function asEnumValue<T extends string>(values: readonly T[], v: unknown, fallback: T): T {
+  const s = asString(v);
+  return (values as readonly string[]).includes(s) ? (s as T) : fallback;
+}
+
+function fromJson(x: any): Foragable {
+  return {
+    id: asString(x?.id),
+    name: asString(x?.name),
+    effectType: asEnumValue(FORAGABLE_EFFECT_TYPES, x?.effectType, 'General Purpose' as ForagableEffectType),
+    form: x?.form != null ? asString(x.form) : undefined,
+    difficulty: asEnumValue(MANOEUVRE_DIFFICULTIES, x?.difficulty, 'Medium' as ManoeuvreDifficulty),
+    preparationType: asEnumValue(FORAGABLE_PREPARATION_TYPES, x?.preparationType, 'Ingest' as ForagablePreparationType),
+    addictionFactor: asInt(x?.addictionFactor),
+    cost: x?.cost != null ? asString(x.cost) : undefined,
+    location: x?.location != null
+      ? {
+        features: asFeatureArray(x.location.features),
+        terrains: asTerrainArray(x.location.terrains),
+        vegetation: asVegetationArray(x.location.vegetation),
+        waterSources: asWaterBodyArray(x.location.waterSources),
+        climates: asStringArray(x.location.climates),
+      }
+      : undefined,
+    effect: x?.effect != null ? asString(x.effect) : undefined,
+  };
+}
+
+export async function fetchForagables(): Promise<Foragable[]> {
+  const data = await fetchJson<ForagablesPayload>(BASE);
+  if (!data || !Array.isArray((data as any).foragables)) {
+    throw new Error('Unexpected response: expected { foragables: [...] }');
+  }
+  return (data as any).foragables.map(fromJson);
+}
+
+export async function upsertForagable(
+  foragable: Foragable,
+  opts: { method?: 'POST' | 'PUT' } = {},
+) {
+  const { method = 'POST' } = opts;
+  return sendJson(BASE, method, foragable);
+}
+
+export async function deleteForagable(id: string) {
+  if (!id) throw new Error('deleteForagable: id is required');
+  await fetchJson<void>(`${BASE}/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 export * from './armourtype';
 export * from './animal';
+export * from './foragable';
 export * from './attacktable';
 export * from './book';
 export * from './character';

--- a/src/endpoints/foragable/ForagableView.tsx
+++ b/src/endpoints/foragable/ForagableView.tsx
@@ -1,0 +1,709 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  fetchForagables,
+  upsertForagable,
+  deleteForagable,
+  fetchClimates,
+} from '../../api';
+
+import {
+  CheckboxGroup,
+  DataTable,
+  type DataTableHandle,
+  DataTableSearchInput,
+  type ColumnDef,
+  IdListEditor,
+  LabeledInput,
+  LabeledSelect,
+  MarkupPreview,
+  PillList,
+  Spinner,
+  useConfirm,
+  useToast,
+} from '../../components';
+
+import type {
+  Climate,
+  Foragable,
+} from '../../types';
+
+import {
+  ENVIRONMENT_FEATURES,
+  ENVIRONMENT_TERRAINS,
+  ENVIRONMENT_VEGETATIONS,
+  ENVIRONMENT_WATER_BODIES,
+  FORAGABLE_EFFECT_TYPES,
+  FORAGABLE_PREPARATION_TYPES,
+  MANOEUVRE_DIFFICULTIES,
+  type EnvironmentFeature,
+  type EnvironmentTerrain,
+  type EnvironmentVegetation,
+  type EnvironmentWaterBody,
+  type ForagableEffectType,
+  type ForagablePreparationType,
+  type ManoeuvreDifficulty,
+} from '../../types/enum';
+
+import {
+  isValidID,
+  isValidUnsignedInt,
+  makeIDOnChange,
+  sanitizeUnsignedInt,
+} from '../../utils';
+
+const prefix = 'FORAGABLE_';
+
+/* ------------------------------------------------------------------ */
+/* VM types                                                           */
+/* ------------------------------------------------------------------ */
+
+type FormState = {
+  id: string;
+  name: string;
+  effectType: ForagableEffectType;
+  form: string;
+  difficulty: ManoeuvreDifficulty;
+  preparationType: ForagablePreparationType;
+  addictionFactor: string;
+  cost: string;
+  locationFeatures: EnvironmentFeature[];
+  locationTerrains: EnvironmentTerrain[];
+  locationVegetation: EnvironmentVegetation[];
+  locationWaterSources: EnvironmentWaterBody[];
+  locationClimates: string[];
+  effect: string;
+};
+
+type FormErrors = {
+  id?: string | undefined;
+  name?: string | undefined;
+  effectType?: string | undefined;
+  difficulty?: string | undefined;
+  preparationType?: string | undefined;
+  addictionFactor?: string | undefined;
+};
+
+const emptyVM = (): FormState => ({
+  id: prefix,
+  name: '',
+  effectType: 'General Purpose',
+  form: '',
+  difficulty: 'Medium',
+  preparationType: 'Ingest',
+  addictionFactor: '0',
+  cost: '',
+  locationFeatures: [],
+  locationTerrains: [],
+  locationVegetation: [],
+  locationWaterSources: [],
+  locationClimates: [],
+  effect: '',
+});
+
+const toVM = (x: Foragable): FormState => ({
+  id: x.id,
+  name: x.name,
+  effectType: x.effectType,
+  form: x.form ?? '',
+  difficulty: x.difficulty,
+  preparationType: x.preparationType,
+  addictionFactor: String(x.addictionFactor),
+  cost: x.cost ?? '',
+  locationFeatures: x.location?.features ?? [],
+  locationTerrains: x.location?.terrains ?? [],
+  locationVegetation: x.location?.vegetation ?? [],
+  locationWaterSources: x.location?.waterSources ?? [],
+  locationClimates: x.location?.climates ?? [],
+  effect: x.effect ?? '',
+});
+
+const fromVM = (vm: FormState): Foragable => {
+  const hasLocation =
+    vm.locationFeatures.length > 0 ||
+    vm.locationTerrains.length > 0 ||
+    vm.locationVegetation.length > 0 ||
+    vm.locationWaterSources.length > 0 ||
+    vm.locationClimates.length > 0;
+
+  return {
+    id: vm.id.trim(),
+    name: vm.name.trim(),
+    effectType: vm.effectType,
+    form: vm.form.trim() || undefined,
+    difficulty: vm.difficulty,
+    preparationType: vm.preparationType,
+    addictionFactor: Number(vm.addictionFactor),
+    cost: vm.cost.trim() || undefined,
+    location: hasLocation
+      ? {
+        features: vm.locationFeatures.slice(),
+        terrains: vm.locationTerrains.slice(),
+        vegetation: vm.locationVegetation.slice(),
+        waterSources: vm.locationWaterSources.slice(),
+        climates: vm.locationClimates.slice(),
+      }
+      : undefined,
+    effect: vm.effect.trim() || undefined,
+  };
+};
+
+/* ------------------------------------------------------------------ */
+/* View                                                               */
+/* ------------------------------------------------------------------ */
+
+export default function ForagableView() {
+  const dtRef = useRef<DataTableHandle>(null);
+
+  const [rows, setRows] = useState<Foragable[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const hasErrors = Object.values(errors).some(Boolean);
+
+  const [climates, setClimates] = useState<Climate[]>([]);
+
+  const [query, setQuery] = useState('');
+  const [effectTypeFilter, setEffectTypeFilter] = useState<ForagableEffectType | ''>('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [viewing, setViewing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyVM());
+
+  const [previewEffect, setPreviewEffect] = useState(false);
+
+  const toast = useToast();
+  const confirm = useConfirm();
+
+  /* ------------------------------------------------------------------ */
+  /* Load data                                                          */
+  /* ------------------------------------------------------------------ */
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [foragables, climateRows] = await Promise.all([
+          fetchForagables(),
+          fetchClimates(),
+        ]);
+        setRows(foragables);
+        setClimates(climateRows);
+      } catch (e) {
+        setError(String(e));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  /* ------------------------------------------------------------------ */
+  /* Options                                                           */
+  /* ------------------------------------------------------------------ */
+
+  const climateNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const row of climates) map.set(row.id, row.name);
+    return map;
+  }, [climates]);
+
+  const climateOptions = useMemo(
+    () => climates.map((row) => ({ value: row.id, label: row.name })),
+    [climates],
+  );
+
+  const effectTypeOptions = useMemo(
+    () => FORAGABLE_EFFECT_TYPES.map((value) => ({ value, label: value })),
+    [],
+  );
+  const difficultyOptions = useMemo(
+    () => MANOEUVRE_DIFFICULTIES.map((value) => ({ value, label: value })),
+    [],
+  );
+  const preparationTypeOptions = useMemo(
+    () => FORAGABLE_PREPARATION_TYPES.map((value) => ({ value, label: value })),
+    [],
+  );
+  const featureOptions = useMemo(() => ENVIRONMENT_FEATURES.map((value) => ({ value, label: value })), []);
+  const terrainOptions = useMemo(() => ENVIRONMENT_TERRAINS.map((value) => ({ value, label: value })), []);
+  const vegetationOptions = useMemo(() => ENVIRONMENT_VEGETATIONS.map((value) => ({ value, label: value })), []);
+  const waterBodyOptions = useMemo(() => ENVIRONMENT_WATER_BODIES.map((value) => ({ value, label: value })), []);
+
+  /* ------------------------------------------------------------------ */
+  /* Validation                                                         */
+  /* ------------------------------------------------------------------ */
+
+  const computeErrors = (draft: FormState): FormErrors => {
+    const next: FormErrors = {};
+
+    const id = draft.id.trim();
+    if (!id) next.id = 'ID is required';
+    else if (!editingId && rows.some((row) => row.id === id)) next.id = `ID "${id}" already exists`;
+    else if (!isValidID(id, prefix)) next.id = `ID must start with "${prefix}" and contain additional characters`;
+
+    if (!draft.name.trim()) next.name = 'Name is required';
+
+    if (!draft.effectType) next.effectType = 'Effect type is required';
+    if (!draft.difficulty) next.difficulty = 'Difficulty is required';
+    if (!draft.preparationType) next.preparationType = 'Preparation type is required';
+
+    const af = draft.addictionFactor.trim();
+    if (!isValidUnsignedInt(af)) {
+      next.addictionFactor = 'Addiction factor must be an integer between 0 and 100';
+    } else {
+      const n = Number(af);
+      if (n > 100) next.addictionFactor = 'Addiction factor must be between 0 and 100';
+    }
+
+    return next;
+  };
+
+  useEffect(() => {
+    if (!showForm || viewing) return;
+    setErrors(computeErrors(form));
+  }, [form, showForm, viewing]);
+
+  /* ------------------------------------------------------------------ */
+  /* Table                                                              */
+  /* ------------------------------------------------------------------ */
+
+  const columns: ColumnDef<Foragable>[] = useMemo(() => [
+    { id: 'id', header: 'ID', accessor: (row) => row.id, sortType: 'string', minWidth: 260 },
+    { id: 'name', header: 'Name', accessor: (row) => row.name, sortType: 'string', minWidth: 180 },
+    { id: 'effectType', header: 'Effect Type', accessor: (row) => row.effectType, sortType: 'string', minWidth: 200 },
+    { id: 'difficulty', header: 'Difficulty', accessor: (row) => row.difficulty, sortType: 'string', minWidth: 120 },
+    { id: 'preparationType', header: 'Preparation', accessor: (row) => row.preparationType, sortType: 'string', minWidth: 120 },
+    {
+      id: 'actions',
+      header: 'Actions',
+      sortable: false,
+      width: 360,
+      render: (row) => (
+        <>
+          <button onClick={() => startView(row)}>View</button>
+          <button onClick={() => startEdit(row)}>Edit</button>
+          <button onClick={() => startDuplicate(row)}>Duplicate</button>
+          <button onClick={() => onDelete(row)} style={{ color: '#b00020' }}>Delete</button>
+        </>
+      ),
+    },
+  ], []);
+
+  const globalFilter = (row: Foragable, q: string) =>
+    [row.id, row.name, row.effectType, row.difficulty, row.preparationType, row.effect ?? '']
+      .some((value) => String(value).toLowerCase().includes(q.toLowerCase()));
+
+  const filteredRows = useMemo(
+    () => rows.filter((row) => !effectTypeFilter || row.effectType === effectTypeFilter),
+    [rows, effectTypeFilter],
+  );
+
+  const hasActiveFilters = effectTypeFilter !== '';
+
+  useEffect(() => {
+    setPage(1);
+  }, [effectTypeFilter]);
+
+  /* ------------------------------------------------------------------ */
+  /* Actions                                                            */
+  /* ------------------------------------------------------------------ */
+
+  const startNew = () => {
+    setViewing(false);
+    setEditingId(null);
+    setForm(emptyVM());
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startView = (row: Foragable) => {
+    setViewing(true);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startEdit = (row: Foragable) => {
+    setViewing(false);
+    setEditingId(row.id);
+    setForm(toVM(row));
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const startDuplicate = (row: Foragable) => {
+    setViewing(false);
+    setEditingId(null);
+    const vm = toVM(row);
+    vm.id = prefix;
+    vm.name += ' (Copy)';
+    setForm(vm);
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const cancelForm = () => {
+    setShowForm(false);
+    setViewing(false);
+    setEditingId(null);
+    setErrors({});
+  };
+
+  const saveForm = async () => {
+    if (submitting) return;
+
+    const nextErrors = computeErrors(form);
+    setErrors(nextErrors);
+    if (Object.values(nextErrors).some(Boolean)) return;
+
+    setSubmitting(true);
+    const payload = fromVM(form);
+    const isEditing = Boolean(editingId);
+
+    try {
+      const opts = isEditing
+        ? { method: 'PUT' as const }
+        : { method: 'POST' as const };
+      await upsertForagable(payload, opts);
+
+      setRows((prev) => {
+        if (isEditing) {
+          const index = prev.findIndex((row) => row.id === payload.id);
+          if (index >= 0) {
+            const copy = prev.slice();
+            copy[index] = { ...copy[index], ...payload };
+            return copy;
+          }
+        }
+        return [payload, ...prev];
+      });
+
+      setShowForm(false);
+      setViewing(false);
+      setEditingId(null);
+
+      toast({
+        variant: 'success',
+        title: isEditing ? 'Updated' : 'Saved',
+        description: `Foragable "${payload.id}" ${isEditing ? 'updated' : 'created'}.`,
+      });
+    } catch (err) {
+      toast({
+        variant: 'danger',
+        title: 'Save failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onDelete = async (row: Foragable) => {
+    if (submitting) return;
+    setSubmitting(true);
+
+    const ok = await confirm({
+      title: 'Delete Foragable',
+      body: `Delete "${row.id}"? This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      tone: 'danger',
+    });
+
+    if (!ok) {
+      setSubmitting(false);
+      return;
+    }
+
+    const previous = rows;
+    setRows((current) => current.filter((item) => item.id !== row.id));
+    setPage(1);
+
+    try {
+      await deleteForagable(row.id);
+      if (editingId === row.id || viewing) cancelForm();
+      toast({ variant: 'success', title: 'Deleted', description: `Foragable "${row.id}" deleted.` });
+    } catch (err) {
+      setRows(previous);
+      toast({
+        variant: 'danger',
+        title: 'Delete failed',
+        description: String(err instanceof Error ? err.message : err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  /* ------------------------------------------------------------------ */
+  /* Render                                                             */
+  /* ------------------------------------------------------------------ */
+
+  if (loading) return <div>Loading…</div>;
+  if (error) return <div style={{ color: 'crimson' }}>{error}</div>;
+
+  return (
+    <>
+      <h2>Foragables</h2>
+
+      {!showForm && (
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+          <button onClick={startNew}>New Foragable</button>
+          <DataTableSearchInput
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search foragables…"
+            aria-label="Search foragables"
+          />
+          <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ fontSize: 14 }}>Effect Type</span>
+            <select
+              value={effectTypeFilter}
+              onChange={(e) => setEffectTypeFilter(e.target.value as ForagableEffectType | '')}
+              aria-label="Filter by effect type"
+              style={{ padding: '6px 8px' }}
+            >
+              <option value="">All</option>
+              {FORAGABLE_EFFECT_TYPES.map((value) => (
+                <option key={value} value={value}>{value}</option>
+              ))}
+            </select>
+          </label>
+          {hasActiveFilters && (
+            <button type="button" onClick={() => setEffectTypeFilter('')}>
+              Clear filters
+            </button>
+          )}
+          <button onClick={() => dtRef.current?.resetColumnWidths()} title="Reset all column widths" style={{ marginLeft: 'auto' }}>Reset column widths</button>
+          <button onClick={() => dtRef.current?.autoFitAllColumns()}>Auto-fit all columns</button>
+        </div>
+      )}
+
+      {showForm && (
+        <div className="form-container">
+          {submitting && (
+            <div className="overlay">
+              <Spinner size={24} />
+              <span>Saving…</span>
+            </div>
+          )}
+
+          <div className={`form-panel ${viewing ? 'form-panel--view' : ''}`}>
+            <h3>{viewing ? 'View' : editingId ? 'Edit' : 'New'} Foragable</h3>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+              <LabeledInput
+                label="ID"
+                value={form.id}
+                onChange={makeIDOnChange<typeof form>('id', setForm, prefix)}
+                disabled={!!editingId || viewing}
+                error={viewing ? undefined : errors.id}
+              />
+              <LabeledInput
+                label="Name"
+                value={form.name}
+                onChange={(value) => setForm((state) => ({ ...state, name: value }))}
+                disabled={viewing}
+                error={viewing ? undefined : errors.name}
+              />
+              <LabeledSelect
+                label="Effect Type"
+                value={form.effectType}
+                onChange={(value) => setForm((state) => ({ ...state, effectType: value as ForagableEffectType }))}
+                options={effectTypeOptions}
+                disabled={viewing}
+                error={viewing ? undefined : errors.effectType}
+              />
+              <LabeledInput
+                label="Form"
+                value={form.form}
+                onChange={(value) => setForm((state) => ({ ...state, form: value }))}
+                disabled={viewing}
+              />
+              <LabeledSelect
+                label="Difficulty"
+                value={form.difficulty}
+                onChange={(value) => setForm((state) => ({ ...state, difficulty: value as ManoeuvreDifficulty }))}
+                options={difficultyOptions}
+                disabled={viewing}
+                error={viewing ? undefined : errors.difficulty}
+              />
+              <LabeledSelect
+                label="Preparation Type"
+                value={form.preparationType}
+                onChange={(value) => setForm((state) => ({ ...state, preparationType: value as ForagablePreparationType }))}
+                options={preparationTypeOptions}
+                disabled={viewing}
+                error={viewing ? undefined : errors.preparationType}
+              />
+              <LabeledInput
+                label="Addiction Factor"
+                value={form.addictionFactor}
+                onChange={(value) => setForm((state) => ({ ...state, addictionFactor: sanitizeUnsignedInt(value) }))}
+                disabled={viewing}
+                error={viewing ? undefined : errors.addictionFactor}
+                inputProps={{ inputMode: 'numeric', pattern: '\\d*' }}
+              />
+              <LabeledInput
+                label="Cost"
+                value={form.cost}
+                onChange={(value) => setForm((state) => ({ ...state, cost: value }))}
+                disabled={viewing}
+              />
+            </div>
+
+            {/* Effect */}
+            <section style={{ marginTop: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <h4 style={{ margin: '8px 0' }}>Effect</h4>
+                {!viewing && (
+                  <button type="button" onClick={() => setPreviewEffect((p) => !p)}>
+                    {previewEffect ? 'Edit' : 'Preview'}
+                  </button>
+                )}
+              </div>
+              {previewEffect || viewing ? (
+                <MarkupPreview
+                  content={form.effect}
+                  emptyHint="No effect"
+                  className="preview-html"
+                  style={{ border: '1px solid var(--border)', borderRadius: 6, padding: 8 }}
+                />
+              ) : (
+                <label style={{ display: 'grid', gap: 6 }}>
+                  <textarea
+                    value={form.effect}
+                    onChange={(e) => setForm((state) => ({ ...state, effect: e.target.value }))}
+                    disabled={viewing}
+                    rows={3}
+                  />
+                </label>
+              )}
+            </section>
+
+            {/* Location */}
+            <section style={{ marginTop: 16, display: 'grid', gap: 16 }}>
+              <h4 style={{ margin: 0 }}>Location</h4>
+              {viewing ? (
+                <>
+                  <div style={{ display: 'grid', gap: 6 }}>
+                    <span style={{ fontSize: 14 }}>Climates</span>
+                    <PillList
+                      values={form.locationClimates}
+                      getLabel={(value) => climateNameById.get(value) ?? value}
+                      emptyLabel="No climates"
+                    />
+                  </div>
+                  <div style={{ display: 'grid', gap: 6 }}>
+                    <span style={{ fontSize: 14 }}>Environment Tags</span>
+                    <PillList
+                      values={[
+                        ...form.locationFeatures.map((value) => `Feature: ${value}`),
+                        ...form.locationTerrains.map((value) => `Terrain: ${value}`),
+                        ...form.locationVegetation.map((value) => `Vegetation: ${value}`),
+                        ...form.locationWaterSources.map((value) => `Water Source: ${value}`),
+                      ]}
+                      emptyLabel="No environment tags"
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <IdListEditor
+                    title="Climates"
+                    rows={form.locationClimates}
+                    onChangeRows={(next) => setForm((state) => ({ ...state, locationClimates: next }))}
+                    options={climateOptions}
+                    columnLabel="Climate"
+                    addButtonLabel="+ Add climate"
+                    viewing={viewing}
+                  />
+                  <CheckboxGroup
+                    label="Features"
+                    value={form.locationFeatures}
+                    onChange={(next) => setForm((state) => ({ ...state, locationFeatures: next as EnvironmentFeature[] }))}
+                    options={featureOptions}
+                    disabled={viewing}
+                    columns={2}
+                  />
+                  <CheckboxGroup
+                    label="Terrains"
+                    value={form.locationTerrains}
+                    onChange={(next) => setForm((state) => ({ ...state, locationTerrains: next as EnvironmentTerrain[] }))}
+                    options={terrainOptions}
+                    disabled={viewing}
+                    columns={2}
+                  />
+                  <CheckboxGroup
+                    label="Vegetation"
+                    value={form.locationVegetation}
+                    onChange={(next) => setForm((state) => ({ ...state, locationVegetation: next as EnvironmentVegetation[] }))}
+                    options={vegetationOptions}
+                    disabled={viewing}
+                    columns={2}
+                  />
+                  <CheckboxGroup
+                    label="Water Sources"
+                    value={form.locationWaterSources}
+                    onChange={(next) => setForm((state) => ({ ...state, locationWaterSources: next as EnvironmentWaterBody[] }))}
+                    options={waterBodyOptions}
+                    disabled={viewing}
+                    columns={2}
+                  />
+                </>
+              )}
+            </section>
+
+            {/* Action buttons */}
+            <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+              {!viewing && (
+                <button onClick={saveForm} disabled={hasErrors || submitting}>
+                  {submitting ? 'Submitting…' : 'Save'}
+                </button>
+              )}
+              <button onClick={cancelForm} type="button">
+                {viewing ? 'Close' : 'Cancel'}
+              </button>
+            </div>
+
+            {/* Validation errors */}
+            {Object.values(errors).some(Boolean) && (
+              <div style={{ marginTop: 12, color: '#b00020' }}>
+                <h4 style={{ margin: '0 0 4px' }}>Please fix the following errors:</h4>
+                <ul style={{ margin: 0, paddingLeft: 20 }}>
+                  {Object.entries(errors).map(([field, message]) =>
+                    message ? <li key={field}>{message}</li> : null,
+                  )}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!showForm && (
+        <DataTable
+          ref={dtRef}
+          rows={filteredRows}
+          columns={columns}
+          rowId={(row) => row.id}
+          initialSort={{ colId: 'name', dir: 'asc' }}
+          searchQuery={query}
+          globalFilter={globalFilter}
+          mode="client"
+          page={page}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          tableMinWidth={0}
+          persistKey="dt.foragables.v1"
+          ariaLabel="Foragable data"
+        />
+      )}
+    </>
+  );
+}

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -1,6 +1,7 @@
 import { lazy, type LazyExoticComponent, type ComponentType } from 'react';
 
 const AnimalView = lazy(() => import('../endpoints/animal/AnimalView'));
+const ForagableView = lazy(() => import('../endpoints/foragable/ForagableView'));
 const ArmourTypeView = lazy(() => import('../endpoints/armourtype/ArmourTypeView'));
 const AttackTableView = lazy(() => import('../endpoints/attacktable/AttackTableView'));
 const BookView = lazy(() => import('../endpoints/book/BookView'));
@@ -38,6 +39,7 @@ export interface ResourceDef {
 
 const known: Record<string, ResourceDef> = {
   animal: { prefix: 'animal', label: 'Animals', path: '/animals', Component: AnimalView },
+  foragable: { prefix: 'foragable', label: 'Foragables', path: '/foragables', Component: ForagableView },
   armourtype: { prefix: 'armourtype', label: 'Armour Types', path: '/armourtypes', Component: ArmourTypeView },
   attacktable: { prefix: 'attacktable', label: 'Attack Tables', path: '/attacktables', Component: AttackTableView },
   book: { prefix: 'book', label: 'Books', path: '/books', Component: BookView },

--- a/src/types/animal.ts
+++ b/src/types/animal.ts
@@ -1,4 +1,5 @@
 import { Named } from './base';
+import { Location } from './location';
 
 import type {
   AnimalOutlookType,
@@ -11,20 +12,10 @@ import type {
   CriticalSize,
   CriticalSizeTableType,
   CriticalType,
-  EnvironmentFeature,
-  EnvironmentTerrain,
-  EnvironmentVegetation,
-  EnvironmentWaterBody,
   LevelVarianceType,
 } from './enum';
 
-export interface AnimalLocation {
-  features: EnvironmentFeature[];
-  terrains: EnvironmentTerrain[];
-  vegetation: EnvironmentVegetation[];
-  waterSources: EnvironmentWaterBody[];
-  climates: string[];
-}
+export type { Location as AnimalLocation };
 
 export interface AnimalRange {
   min: number;
@@ -92,7 +83,7 @@ export interface Animal extends Named {
   criticalModifiers: CriticalModifierType[];
   encounterRange?: AnimalRange | undefined;
   numberYoungRange?: AnimalRange | undefined;
-  location?: AnimalLocation | undefined;
+  location?: Location | undefined;
   standardAttacks: AnimalStandardAttack[];
   rangedAttacks: AnimalRangedAttack[];
   conditionalAttacks: AnimalConditionalAttack[];

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -179,3 +179,11 @@ export const CRITICAL_TABLE_TYPES: ReadonlyArray<CriticalTableType> = ['Normal',
 export type ResistanceType = 'Arcane' | 'Channeling' | 'ChannelingEssence' | 'ChannelingMentalism' | 'Cold' | 'Disease' | 'Essence' | 'EssenceMentalism' | 'Fear' | 'Heat' | 'Mentalism' | 'Poison';
 export const RESISTANCE_TYPES: ReadonlyArray<ResistanceType> = ['Arcane', 'Channeling', 'ChannelingEssence', 'ChannelingMentalism', 'Cold', 'Disease', 'Essence', 'EssenceMentalism', 'Fear', 'Heat', 'Mentalism', 'Poison'] as const;
 export const BASE_RESISTANCE_TYPES: ReadonlyArray<ResistanceType> = ['Arcane', 'Channeling', 'Cold', 'Disease', 'Essence', 'Fear', 'Heat', 'Mentalism', 'Poison'] as const;
+
+/** Enum for foragable effect types */
+export type ForagableEffectType = 'Antidote' | 'Bone Repair' | 'Burn & Exposure Relief' | 'Circulatory Repair' | 'Circulatory Poison' | 'Concussion Relief' | 'Conversion Poison' | 'General Purpose' | 'Intoxicant' | 'Life Preservation' | 'Muscle Cartilage & Tendon Repair' | 'Muscle Poison' | 'Nerve Poison' | 'Nerve Repair' | 'Organ Repair & Preservation' | 'Physical Alteration & Enhancement' | 'Reduction Poison' | 'Respitory Poison' | 'Stat Modifier' | 'Stun Relief';
+export const FORAGABLE_EFFECT_TYPES: ReadonlyArray<ForagableEffectType> = ['Antidote', 'Bone Repair', 'Burn & Exposure Relief', 'Circulatory Repair', 'Circulatory Poison', 'Concussion Relief', 'Conversion Poison', 'General Purpose', 'Intoxicant', 'Life Preservation', 'Muscle Cartilage & Tendon Repair', 'Muscle Poison', 'Nerve Poison', 'Nerve Repair', 'Organ Repair & Preservation', 'Physical Alteration & Enhancement', 'Reduction Poison', 'Respitory Poison', 'Stat Modifier', 'Stun Relief'] as const;
+
+/** Enum for foragable preparation types */
+export type ForagablePreparationType = 'Apply' | 'Brew' | 'Ingest' | 'Liquid' | 'Paste' | 'Powder';
+export const FORAGABLE_PREPARATION_TYPES: ReadonlyArray<ForagablePreparationType> = ['Apply', 'Brew', 'Ingest', 'Liquid', 'Paste', 'Powder'] as const;

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -98,8 +98,8 @@ export function asVegetationArray(v: unknown): EnvironmentVegetation[] {
 }
 
 /** Enum for Environment water bodies */
-export type EnvironmentWaterBody = 'Breaks' | 'Desert' | 'Fresh Coast' | 'Glacier' | 'Islet' | 'Lake' | 'Marsh' | 'Oasis' | 'Ocean' | 'Salt Coast';
-export const ENVIRONMENT_WATER_BODIES: ReadonlyArray<EnvironmentWaterBody> = ['Breaks', 'Desert', 'Fresh Coast', 'Glacier', 'Islet', 'Lake', 'Marsh', 'Oasis', 'Ocean', 'Salt Coast'] as const;
+export type EnvironmentWaterBody = 'Breaks' | 'Desert' | 'Freshwater Coast' | 'Glacier' | 'Islet' | 'Lake' | 'Marsh' | 'Oasis' | 'Ocean' | 'Saltwater Coast';
+export const ENVIRONMENT_WATER_BODIES: ReadonlyArray<EnvironmentWaterBody> = ['Breaks', 'Desert', 'Freshwater Coast', 'Glacier', 'Islet', 'Lake', 'Marsh', 'Oasis', 'Ocean', 'Saltwater Coast'] as const;
 const WATER_BODY_SET = new Set<EnvironmentWaterBody>(ENVIRONMENT_WATER_BODIES);
 export function asWaterBodyArray(v: unknown): EnvironmentWaterBody[] {
   if (!Array.isArray(v)) return [];

--- a/src/types/foragable.ts
+++ b/src/types/foragable.ts
@@ -1,0 +1,22 @@
+import { Named } from './base';
+import type { Location } from './location';
+import type {
+  ForagableEffectType,
+  ForagablePreparationType,
+  ManoeuvreDifficulty,
+} from './enum';
+
+export interface Foragable extends Named {
+  effectType: ForagableEffectType;
+  form?: string | undefined;
+  difficulty: ManoeuvreDifficulty;
+  preparationType: ForagablePreparationType;
+  addictionFactor: number;
+  cost?: string | undefined;
+  location?: Location | undefined;
+  effect?: string | undefined;
+}
+
+export interface ForagablesPayload {
+  foragables: Foragable[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,7 @@
 export * from './armourtype';
 export * from './animal';
+export * from './foragable';
+export * from './location';
 export * from './attacktable';
 export * from './base';
 export * from './book';

--- a/src/types/location.ts
+++ b/src/types/location.ts
@@ -1,0 +1,14 @@
+import type {
+  EnvironmentFeature,
+  EnvironmentTerrain,
+  EnvironmentVegetation,
+  EnvironmentWaterBody,
+} from './enum';
+
+export interface Location {
+  features: EnvironmentFeature[];
+  terrains: EnvironmentTerrain[];
+  vegetation: EnvironmentVegetation[];
+  waterSources: EnvironmentWaterBody[];
+  climates: string[];
+}


### PR DESCRIPTION
This pull request introduces a new "foragable" resource to the codebase, including its API, type definitions, and registry integration. It also refactors how environment/location types are handled for both animals and foragables, and adds new enums for foragable-specific properties. Additionally, it corrects and expands the set of environment water body types.

**New foragable resource and API:**

- Added a new `foragable` API module with functions to fetch, upsert, and delete foragable resources, along with robust type conversion and validation (`src/api/foragable.ts`).
- Defined the `Foragable` and `ForagablesPayload` interfaces, including properties for effect type, preparation type, difficulty, addiction factor, cost, location, and effect (`src/types/foragable.ts`).
- Registered the foragable resource in the resource registry for UI routing and lazy loading (`src/resources/registry.ts`) [[1]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R4) [[2]](diffhunk://#diff-6fe8743a45fc705a3304754648f02815ea1c96e5e71a1bccad4bc1d6a46738b4R42).
- Exported the new foragable types and API from the main type and API index files (`src/types/index.ts`, `src/api/index.ts`) [[1]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R3-R4) [[2]](diffhunk://#diff-764761d79ed791ea154187526b088322dba3bebe94f9d38ab22120554aba77c7R3).

**Location and environment type refactoring:**

- Introduced a shared `Location` type for use by both animals and foragables, consolidating environment-related properties into a single interface (`src/types/location.ts`).
- Updated the `Animal` interface to use the new `Location` type instead of its own `AnimalLocation` interface, and re-exported `Location` as `AnimalLocation` for compatibility (`src/types/animal.ts`) [[1]](diffhunk://#diff-4cbb37f2f4b554d9dfc4d7897062dadfe16f025495e0cf351950db76ef886cf5R2) [[2]](diffhunk://#diff-4cbb37f2f4b554d9dfc4d7897062dadfe16f025495e0cf351950db76ef886cf5L14-R18) [[3]](diffhunk://#diff-4cbb37f2f4b554d9dfc4d7897062dadfe16f025495e0cf351950db76ef886cf5L95-R86).

**Foragable enums and environment water body correction:**

- Added enums for `ForagableEffectType` and `ForagablePreparationType` to support new foragable properties (`src/types/enum.ts`).
- Corrected and expanded the `EnvironmentWaterBody` enum, renaming "Fresh Coast" to "Freshwater Coast" and "Salt Coast" to "Saltwater Coast" for clarity and accuracy (`src/types/enum.ts`).